### PR TITLE
feat: add ProjectContext model with S3 sync

### DIFF
--- a/mrvn/agents/migrations/0007_project_context.py
+++ b/mrvn/agents/migrations/0007_project_context.py
@@ -1,0 +1,39 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0002_customer"),
+        ("agents", "0006_customer"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ProjectContext",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_datetime", models.DateTimeField(auto_now_add=True)),
+                ("updated_datetime", models.DateTimeField(auto_now=True)),
+                ("project_id", models.CharField(help_text="GitHub project node ID", max_length=255)),
+                ("repo_owner", models.CharField(max_length=255)),
+                ("repo_name", models.CharField(max_length=255)),
+                ("goals_markdown", models.TextField(blank=True, help_text="Pulled from project README")),
+                ("sops_snapshot", models.JSONField(default=dict, help_text="Cached SOP content from S3")),
+                ("s3_prefix", models.CharField(help_text="s3://bucket/customer/projects/repo/", max_length=512)),
+                ("last_synced", models.DateTimeField(blank=True, null=True)),
+                (
+                    "customer",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="project_contexts",
+                        to="accounts.customer",
+                    ),
+                ),
+            ],
+            options={
+                "unique_together": {("customer", "project_id")},
+            },
+        ),
+    ]

--- a/mrvn/agents/models.py
+++ b/mrvn/agents/models.py
@@ -231,3 +231,26 @@ class AgentTool(TimestampedModel):
 
     def __str__(self) -> str:
         return f"{self.agent.name} - {self.tool.name}"
+
+
+class ProjectContext(TimestampedModel):
+    """Per-customer project goals and SOPs cached from S3, keyed by GitHub project."""
+
+    customer = models.ForeignKey(
+        "accounts.Customer",
+        on_delete=models.CASCADE,
+        related_name="project_contexts",
+    )
+    project_id = models.CharField(max_length=255, help_text="GitHub project node ID")
+    repo_owner = models.CharField(max_length=255)
+    repo_name = models.CharField(max_length=255)
+    goals_markdown = models.TextField(blank=True, help_text="Pulled from project README")
+    sops_snapshot = models.JSONField(default=dict, help_text="Cached SOP content from S3")
+    s3_prefix = models.CharField(max_length=512, help_text="s3://bucket/customer/projects/repo/")
+    last_synced = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        unique_together = [("customer", "project_id")]
+
+    def __str__(self) -> str:
+        return f"{self.customer}/{self.repo_owner}/{self.repo_name}"

--- a/mrvn/agents/services.py
+++ b/mrvn/agents/services.py
@@ -1,0 +1,89 @@
+import base64
+import json
+import logging
+import os
+from urllib.parse import urlparse
+
+import boto3
+import httpx
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API_BASE = "https://api.github.com"
+
+
+def _github_headers() -> dict:
+    token = os.getenv("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_readme(repo_owner: str, repo_name: str) -> str:
+    """Fetch README content from GitHub. Returns empty string if not found."""
+    url = f"{GITHUB_API_BASE}/repos/{repo_owner}/{repo_name}/readme"
+    try:
+        response = httpx.get(url, headers=_github_headers(), timeout=10)
+        if response.status_code == 404:
+            logger.info("No README found for %s/%s", repo_owner, repo_name)
+            return ""
+        response.raise_for_status()
+        data = response.json()
+        encoded = data.get("content", "")
+        return base64.b64decode(encoded).decode("utf-8")
+    except Exception as exc:
+        logger.warning("Failed to fetch README for %s/%s: %s", repo_owner, repo_name, exc)
+        return ""
+
+
+def _list_s3_sop_files(s3_prefix: str) -> dict[str, str]:
+    """List and read SOP files under s3_prefix. Returns {key: content}."""
+    parsed = urlparse(s3_prefix)
+    bucket = parsed.netloc
+    prefix = parsed.path.lstrip("/")
+
+    s3 = boto3.client("s3")
+    result: dict[str, str] = {}
+    try:
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                try:
+                    body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+                    result[key] = body.decode("utf-8")
+                except Exception as exc:
+                    logger.warning("Failed to read S3 object %s: %s", key, exc)
+    except Exception as exc:
+        logger.warning("Failed to list S3 prefix %s: %s", s3_prefix, exc)
+    return result
+
+
+def sync_project_context(project_context_id: int) -> None:
+    """Sync goals_markdown and sops_snapshot for a ProjectContext from GitHub and S3.
+
+    Reads the repository README from GitHub and SOP files from the configured
+    S3 prefix, then updates goals_markdown, sops_snapshot, and last_synced.
+    """
+    from agents.models import ProjectContext
+
+    ctx = ProjectContext.objects.get(pk=project_context_id)
+
+    goals = _fetch_readme(ctx.repo_owner, ctx.repo_name)
+    sops = _list_s3_sop_files(ctx.s3_prefix)
+
+    ctx.goals_markdown = goals
+    ctx.sops_snapshot = sops
+    ctx.last_synced = timezone.now()
+    ctx.save(update_fields=["goals_markdown", "sops_snapshot", "last_synced", "updated_datetime"])
+
+    logger.info(
+        "Synced ProjectContext pk=%s (%s/%s): %d chars README, %d SOP files",
+        ctx.pk,
+        ctx.repo_owner,
+        ctx.repo_name,
+        len(goals),
+        len(sops),
+    )

--- a/mrvn/agents/tests/test_project_context.py
+++ b/mrvn/agents/tests/test_project_context.py
@@ -1,0 +1,110 @@
+"""Tests for ProjectContext model and sync_project_context service."""
+
+from unittest.mock import MagicMock, patch
+
+from accounts.models import Customer
+from django.test import TestCase
+
+from agents.models import ProjectContext
+from agents.services import sync_project_context
+
+
+def _make_customer(**kwargs) -> Customer:
+    defaults = {
+        "name": "Test Corp",
+        "github_org": "test-corp",
+        "s3_context_prefix": "s3://bucket/test-corp/",
+    }
+    defaults.update(kwargs)
+    return Customer.objects.create(**defaults)
+
+
+def _make_project_context(customer: Customer, **kwargs) -> ProjectContext:
+    defaults = {
+        "project_id": "PVT_abc123",
+        "repo_owner": "test-corp",
+        "repo_name": "my-project",
+        "s3_prefix": "s3://bucket/test-corp/projects/my-project/",
+    }
+    defaults.update(kwargs)
+    return ProjectContext.objects.create(customer=customer, **defaults)
+
+
+class ProjectContextModelTest(TestCase):
+    def setUp(self) -> None:
+        self.customer = _make_customer()
+
+    def test_create(self) -> None:
+        ctx = _make_project_context(self.customer)
+        self.assertEqual(ctx.project_id, "PVT_abc123")
+        self.assertEqual(ctx.repo_owner, "test-corp")
+        self.assertEqual(ctx.repo_name, "my-project")
+        self.assertEqual(ctx.goals_markdown, "")
+        self.assertEqual(ctx.sops_snapshot, {})
+        self.assertIsNone(ctx.last_synced)
+
+    def test_str(self) -> None:
+        ctx = _make_project_context(self.customer)
+        self.assertIn("test-corp", str(ctx))
+        self.assertIn("my-project", str(ctx))
+
+    def test_unique_together_customer_project_id(self) -> None:
+        _make_project_context(self.customer)
+        from django.db import IntegrityError
+
+        with self.assertRaises(IntegrityError):
+            _make_project_context(self.customer)
+
+    def test_same_project_id_different_customer(self) -> None:
+        other = _make_customer(name="Other Corp", github_org="other-corp", s3_context_prefix="s3://bucket/other/")
+        _make_project_context(self.customer)
+        ctx2 = _make_project_context(other)
+        self.assertEqual(ctx2.project_id, "PVT_abc123")
+
+    def test_timestamps_set_on_create(self) -> None:
+        ctx = _make_project_context(self.customer)
+        self.assertIsNotNone(ctx.created_datetime)
+        self.assertIsNotNone(ctx.updated_datetime)
+
+
+class SyncProjectContextTest(TestCase):
+    def setUp(self) -> None:
+        self.customer = _make_customer()
+        self.ctx = _make_project_context(self.customer)
+
+    @patch("agents.services._list_s3_sop_files")
+    @patch("agents.services._fetch_readme")
+    def test_sync_updates_fields(self, mock_readme: MagicMock, mock_sops: MagicMock) -> None:
+        mock_readme.return_value = "# My Project\nGoals here."
+        mock_sops.return_value = {"sops/overview.md": "Do things safely."}
+
+        sync_project_context(self.ctx.pk)
+
+        self.ctx.refresh_from_db()
+        self.assertEqual(self.ctx.goals_markdown, "# My Project\nGoals here.")
+        self.assertEqual(self.ctx.sops_snapshot, {"sops/overview.md": "Do things safely."})
+        self.assertIsNotNone(self.ctx.last_synced)
+
+    @patch("agents.services._list_s3_sop_files")
+    @patch("agents.services._fetch_readme")
+    def test_sync_calls_with_correct_args(self, mock_readme: MagicMock, mock_sops: MagicMock) -> None:
+        mock_readme.return_value = ""
+        mock_sops.return_value = {}
+
+        sync_project_context(self.ctx.pk)
+
+        mock_readme.assert_called_once_with("test-corp", "my-project")
+        mock_sops.assert_called_once_with("s3://bucket/test-corp/projects/my-project/")
+
+    @patch("agents.services._list_s3_sop_files")
+    @patch("agents.services._fetch_readme")
+    def test_sync_empty_readme_and_sops(self, mock_readme: MagicMock, mock_sops: MagicMock) -> None:
+        mock_readme.return_value = ""
+        mock_sops.return_value = {}
+
+        sync_project_context(self.ctx.pk)
+
+        self.ctx.refresh_from_db()
+        self.assertEqual(self.ctx.goals_markdown, "")
+        self.assertEqual(self.ctx.sops_snapshot, {})
+        self.assertIsNotNone(self.ctx.last_synced)

--- a/mrvn/memory/migrations/0006_session_project_context.py
+++ b/mrvn/memory/migrations/0006_session_project_context.py
@@ -1,0 +1,24 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("agents", "0007_project_context"),
+        ("memory", "0005_customer"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="session",
+            name="project_context",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="sessions",
+                to="agents.projectcontext",
+            ),
+        ),
+    ]

--- a/mrvn/memory/models.py
+++ b/mrvn/memory/models.py
@@ -49,6 +49,14 @@ class Session(TimestampedModel):
         related_name="sessions",
     )
 
+    project_context = models.ForeignKey(
+        "agents.ProjectContext",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="sessions",
+    )
+
     customer = models.ForeignKey(
         "accounts.Customer",
         on_delete=models.SET_NULL,

--- a/mrvn/mrvn/settings.py
+++ b/mrvn/mrvn/settings.py
@@ -266,6 +266,9 @@ LOGGING = {
 }
 
 AWS_REGION = os.getenv("AWS_DEFAULT_REGION", "ap-northeast-1")
+
+# GitHub API token for reading READMEs (optional — unauthenticated calls are rate-limited)
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
 AWS_DEFAULT_REGION = AWS_REGION
 
 # CSRF Settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     # Production server
     "gunicorn>=23.0.0",
     "httpx>=0.27.0",  # HTTP client for validations
+    "boto3>=1.35.0",  # AWS S3 access for SOP sync
     # API
     "djangorestframework>=3.15.0",
     # Vector search for memory


### PR DESCRIPTION
## Summary

- Add `ProjectContext` model in `agents/` storing per-customer project goals, SOPs, and S3 sync metadata (keyed by GitHub project node ID)
- Add nullable `project_context` FK to `memory.Session`
- Add `sync_project_context(project_context_id)` service that reads README from GitHub and SOP files from S3, updating `goals_markdown`, `sops_snapshot`, and `last_synced`
- Add `boto3` dependency and `GITHUB_TOKEN` setting

Depends on #2 (Customer model) — branched from `feature/2-customer-model-multitenancy`.

Closes #3

## Test plan

- [x] `ProjectContext` model creates and enforces `unique_together (customer, project_id)`
- [x] `Session.project_context` FK is nullable
- [x] `sync_project_context()` calls GitHub README endpoint and S3 SOP prefix, persists results
- [x] Unit tests pass: `python manage.py test agents.tests.test_project_context`