### PR TITLE
fix: SessionsSendTool reuses spawned sessions from _AGENT_SESSIONS

### DIFF
--- a/mrvn/agents/tests/test_coding_tools.py
+++ b/mrvn/agents/tests/test_coding_tools.py
@@ -20,6 +20,7 @@ from agents.tools.coding import (
     SessionsSpawnTool,
     WebFetchTool,
     WriteTool,
+    _SESSION_MANAGER,
 )
 
 
@@ -357,10 +358,7 @@ class SessionsSpawnToolTests(IsolatedAsyncioTestCase):
         self.assertIn("claude", result.error.lower())
 
     async def test_success_spawns_session(self) -> None:
-        from agents.tools.coding import _AGENT_SESSIONS, _AGENT_SESSIONS_LOCK
-
-        with _AGENT_SESSIONS_LOCK:
-            _AGENT_SESSIONS.clear()
+        _SESSION_MANAGER.clear()
 
         mock_proc = MagicMock()
         mock_proc.communicate.return_value = ("agent response", "")
@@ -380,16 +378,10 @@ class SessionsSpawnToolTests(IsolatedAsyncioTestCase):
 class SessionsSendToolTests(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.tool = SessionsSendTool()
-        from agents.tools.coding import _AGENT_SESSIONS, _AGENT_SESSIONS_LOCK
-
-        with _AGENT_SESSIONS_LOCK:
-            _AGENT_SESSIONS.clear()
+        _SESSION_MANAGER.clear()
 
     def tearDown(self) -> None:
-        from agents.tools.coding import _AGENT_SESSIONS, _AGENT_SESSIONS_LOCK
-
-        with _AGENT_SESSIONS_LOCK:
-            _AGENT_SESSIONS.clear()
+        _SESSION_MANAGER.clear()
 
     async def test_session_not_found_returns_error(self) -> None:
         result = await self.tool.execute(session_id="nonexistent", prompt="hello")
@@ -397,14 +389,11 @@ class SessionsSendToolTests(IsolatedAsyncioTestCase):
         self.assertIn("not found", result.error.lower())
 
     async def test_success_sends_message(self) -> None:
-        from agents.tools.coding import _AGENT_SESSIONS, _AGENT_SESSIONS_LOCK
-
         mock_proc = MagicMock()
         mock_proc.communicate.return_value = ("response text", "")
         mock_proc.returncode = 0
 
-        with _AGENT_SESSIONS_LOCK:
-            _AGENT_SESSIONS["s1"] = mock_proc
+        _SESSION_MANAGER.add("s1", mock_proc)
 
         result = await self.tool.execute(session_id="s1", prompt="hello")
         self.assertEqual(result.status, ToolStatus.SUCCESS)
@@ -412,8 +401,6 @@ class SessionsSendToolTests(IsolatedAsyncioTestCase):
 
     async def test_spawn_then_send_uses_same_process(self) -> None:
         """Send must reuse the process stored by spawn, not spawn a fresh subprocess."""
-        from agents.tools.coding import _AGENT_SESSIONS, _AGENT_SESSIONS_LOCK
-
         spawn_tool = SessionsSpawnTool()
 
         mock_proc = MagicMock()
@@ -423,8 +410,7 @@ class SessionsSendToolTests(IsolatedAsyncioTestCase):
         with patch("subprocess.Popen", return_value=mock_proc):
             await spawn_tool.execute(session_id="test_session", prompt="initial prompt")
 
-        with _AGENT_SESSIONS_LOCK:
-            stored_proc = _AGENT_SESSIONS.get("test_session")
+        stored_proc = _SESSION_MANAGER.get("test_session")
         self.assertIs(stored_proc, mock_proc)
 
         with patch("subprocess.Popen") as mock_popen_send:

--- a/mrvn/agents/tools/coding.py
+++ b/mrvn/agents/tools/coding.py
@@ -521,9 +521,31 @@ class RealWebSearchTool(BaseTool):
             return json.loads(resp.read())
 
 
-# Sub-agent session registry: session_id -> subprocess.Popen
-_AGENT_SESSIONS: dict[str, subprocess.Popen] = {}
-_AGENT_SESSIONS_LOCK = threading.Lock()
+class AgentSessionManager:
+    """Thread-safe registry of spawned sub-agent sessions."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, subprocess.Popen] = {}
+        self._lock = threading.Lock()
+
+    def __contains__(self, session_id: str) -> bool:
+        with self._lock:
+            return session_id in self._sessions
+
+    def get(self, session_id: str) -> subprocess.Popen | None:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    def add(self, session_id: str, proc: subprocess.Popen) -> None:
+        with self._lock:
+            self._sessions[session_id] = proc
+
+    def clear(self) -> None:
+        with self._lock:
+            self._sessions.clear()
+
+
+_SESSION_MANAGER = AgentSessionManager()
 
 
 class SessionsSpawnTool(BaseTool):
@@ -559,9 +581,8 @@ class SessionsSpawnTool(BaseTool):
 
     async def execute(self, session_id: str, prompt: str, model: str = "claude-sonnet-4-6") -> ToolResult:
         """Spawn a Claude CLI sub-agent."""
-        with _AGENT_SESSIONS_LOCK:
-            if session_id in _AGENT_SESSIONS:
-                return ToolResult.from_error(f"Session '{session_id}' already exists.")
+        if session_id in _SESSION_MANAGER:
+            return ToolResult.from_error(f"Session '{session_id}' already exists.")
         try:
             proc = subprocess.Popen(  # noqa: S603
                 ["claude", "--model", model, "--print"],  # noqa: S607
@@ -576,8 +597,7 @@ class SessionsSpawnTool(BaseTool):
                     f"Sub-agent failed (code {proc.returncode}): {stderr}",
                     output=stdout,
                 )
-            with _AGENT_SESSIONS_LOCK:
-                _AGENT_SESSIONS[session_id] = proc
+            _SESSION_MANAGER.add(session_id, proc)
             return ToolResult.success(
                 output=stdout,
                 data={"session_id": session_id, "model": model},
@@ -620,8 +640,7 @@ class SessionsSendTool(BaseTool):
 
     async def execute(self, session_id: str, prompt: str, model: str = "claude-sonnet-4-6") -> ToolResult:
         """Send a message to a sub-agent via Claude CLI."""
-        with _AGENT_SESSIONS_LOCK:
-            proc = _AGENT_SESSIONS.get(session_id)
+        proc = _SESSION_MANAGER.get(session_id)
         if proc is None:
             return ToolResult.from_error(f"Session '{session_id}' not found. Use sessions_spawn first.")
         try:


### PR DESCRIPTION
## Summary

- `SessionsSendTool.execute()` now looks up the session process from `_AGENT_SESSIONS` (populated by `SessionsSpawnTool`) instead of spawning a fresh subprocess on every call.
- Returns a clear error message when the requested session ID is not found.
- Adds `pytest` to dev dependencies.
- Updates `SessionsSendToolTests`: replaces the stale subprocess-mock test with session-lookup and same-process-reuse tests that verify the corrected contract.

Closes #19

## Test plan

- [ ] `SessionsSendToolTests::test_session_not_found_returns_error` — missing session returns error
- [ ] `SessionsSendToolTests::test_success_sends_message` — existing session returns response
- [ ] `SessionsSendToolTests::test_spawn_then_send_uses_same_process` — send reuses stored process, `subprocess.Popen` not called a second time
- [ ] All 42 coding-tool tests pass (`pytest mrvn/agents/tests/test_coding_tools.py`)