### PR TITLE
feat: add ProjectContext model with S3 sync (rebased, review addressed)

### DIFF
--- a/mrvn/accounts/migrations/0003_customer_github_token.py
+++ b/mrvn/accounts/migrations/0003_customer_github_token.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0002_customer"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="customer",
+            name="github_token",
+            field=models.CharField(blank=True, help_text="GitHub API token for this organization", max_length=512),
+        ),
+    ]

--- a/mrvn/accounts/models.py
+++ b/mrvn/accounts/models.py
@@ -13,6 +13,7 @@ class Customer(TimestampedModel):
     id = UUID7Field(primary_key=True)
     name = models.CharField(max_length=255)
     github_org = models.CharField(max_length=255, unique=True, blank=True, null=True)
+    github_token = models.CharField(max_length=512, blank=True, help_text="GitHub API token for this organization")
     # Auto-calculated on save: customers/{id}/
     s3_context_prefix = models.CharField(max_length=512, editable=False, blank=True)
     is_active = models.BooleanField(default=True)

--- a/mrvn/agents/migrations/0007_project_context.py
+++ b/mrvn/agents/migrations/0007_project_context.py
@@ -1,0 +1,37 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0003_customer_github_token"),
+        ("agents", "0006_agent_customer"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ProjectContext",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_datetime", models.DateTimeField(auto_now_add=True)),
+                ("updated_datetime", models.DateTimeField(auto_now=True)),
+                ("project_id", models.CharField(help_text="GitHub project node ID", max_length=255)),
+                ("goals_markdown", models.TextField(blank=True, help_text="Project goals (manually set or synced)")),
+                ("sops_snapshot", models.JSONField(default=dict, help_text="Cached SOP content from S3")),
+                ("s3_prefix", models.CharField(help_text="s3://bucket/customer/projects/<name>/", max_length=512)),
+                ("last_synced", models.DateTimeField(blank=True, null=True)),
+                (
+                    "customer",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="project_contexts",
+                        to="accounts.customer",
+                    ),
+                ),
+            ],
+            options={
+                "unique_together": {("customer", "project_id")},
+            },
+        ),
+    ]

--- a/mrvn/agents/models.py
+++ b/mrvn/agents/models.py
@@ -230,3 +230,24 @@ class AgentTool(TimestampedModel):
 
     def __str__(self) -> str:
         return f"{self.agent.name} - {self.tool.name}"
+
+
+class ProjectContext(TimestampedModel):
+    """Per-customer project goals and SOPs cached from S3, keyed by GitHub project."""
+
+    customer = models.ForeignKey(
+        "accounts.Customer",
+        on_delete=models.CASCADE,
+        related_name="project_contexts",
+    )
+    project_id = models.CharField(max_length=255, help_text="GitHub project node ID")
+    goals_markdown = models.TextField(blank=True, help_text="Project goals (manually set or synced)")
+    sops_snapshot = models.JSONField(default=dict, help_text="Cached SOP content from S3")
+    s3_prefix = models.CharField(max_length=512, help_text="s3://bucket/customer/projects/<name>/")
+    last_synced = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        unique_together = [("customer", "project_id")]
+
+    def __str__(self) -> str:
+        return f"{self.customer}/{self.project_id}"

--- a/mrvn/agents/services.py
+++ b/mrvn/agents/services.py
@@ -1,0 +1,54 @@
+import logging
+from urllib.parse import urlparse
+
+import boto3
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+def _list_s3_sop_files(s3_prefix: str) -> dict[str, str]:
+    """List and read SOP files under s3_prefix. Returns {key: content}."""
+    parsed = urlparse(s3_prefix)
+    bucket = parsed.netloc
+    prefix = parsed.path.lstrip("/")
+
+    s3 = boto3.client("s3")
+    result: dict[str, str] = {}
+    try:
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                try:
+                    body = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+                    result[key] = body.decode("utf-8")
+                except Exception as exc:
+                    logger.warning("Failed to read S3 object %s: %s", key, exc)
+    except Exception as exc:
+        logger.warning("Failed to list S3 prefix %s: %s", s3_prefix, exc)
+    return result
+
+
+def sync_project_context(project_context_id: int) -> None:
+    """Sync sops_snapshot for a ProjectContext from S3.
+
+    Reads SOP files from the configured S3 prefix and updates
+    sops_snapshot and last_synced.
+    """
+    from agents.models import ProjectContext
+
+    ctx = ProjectContext.objects.get(pk=project_context_id)
+
+    sops = _list_s3_sop_files(ctx.s3_prefix)
+
+    ctx.sops_snapshot = sops
+    ctx.last_synced = timezone.now()
+    ctx.save(update_fields=["sops_snapshot", "last_synced", "updated_datetime"])
+
+    logger.info(
+        "Synced ProjectContext pk=%s (project=%s): %d SOP files",
+        ctx.pk,
+        ctx.project_id,
+        len(sops),
+    )

--- a/mrvn/agents/tests/test_project_context.py
+++ b/mrvn/agents/tests/test_project_context.py
@@ -1,0 +1,96 @@
+"""Tests for ProjectContext model and sync_project_context service."""
+
+from unittest.mock import MagicMock, patch
+
+from accounts.models import Customer
+from django.test import TestCase
+
+from agents.models import ProjectContext
+from agents.services import sync_project_context
+
+
+def _make_customer(**kwargs) -> Customer:
+    defaults = {
+        "name": "Test Corp",
+        "github_org": "test-corp",
+        "github_token": "ghp_test_token",
+    }
+    defaults.update(kwargs)
+    return Customer.objects.create(**defaults)
+
+
+def _make_project_context(customer: Customer, **kwargs) -> ProjectContext:
+    defaults = {
+        "project_id": "PVT_abc123",
+        "s3_prefix": "s3://bucket/test-corp/projects/my-project/",
+    }
+    defaults.update(kwargs)
+    return ProjectContext.objects.create(customer=customer, **defaults)
+
+
+class ProjectContextModelTest(TestCase):
+    def setUp(self) -> None:
+        self.customer = _make_customer()
+
+    def test_create(self) -> None:
+        ctx = _make_project_context(self.customer)
+        self.assertEqual(ctx.project_id, "PVT_abc123")
+        self.assertEqual(ctx.goals_markdown, "")
+        self.assertEqual(ctx.sops_snapshot, {})
+        self.assertIsNone(ctx.last_synced)
+
+    def test_str(self) -> None:
+        ctx = _make_project_context(self.customer)
+        self.assertIn("PVT_abc123", str(ctx))
+
+    def test_unique_together_customer_project_id(self) -> None:
+        _make_project_context(self.customer)
+        from django.db import IntegrityError
+
+        with self.assertRaises(IntegrityError):
+            _make_project_context(self.customer)
+
+    def test_same_project_id_different_customer(self) -> None:
+        other = _make_customer(name="Other Corp", github_org="other-corp")
+        _make_project_context(self.customer)
+        ctx2 = _make_project_context(other)
+        self.assertEqual(ctx2.project_id, "PVT_abc123")
+
+    def test_timestamps_set_on_create(self) -> None:
+        ctx = _make_project_context(self.customer)
+        self.assertIsNotNone(ctx.created_datetime)
+        self.assertIsNotNone(ctx.updated_datetime)
+
+
+class SyncProjectContextTest(TestCase):
+    def setUp(self) -> None:
+        self.customer = _make_customer()
+        self.ctx = _make_project_context(self.customer)
+
+    @patch("agents.services._list_s3_sop_files")
+    def test_sync_updates_fields(self, mock_sops: MagicMock) -> None:
+        mock_sops.return_value = {"sops/overview.md": "Do things safely."}
+
+        sync_project_context(self.ctx.pk)
+
+        self.ctx.refresh_from_db()
+        self.assertEqual(self.ctx.sops_snapshot, {"sops/overview.md": "Do things safely."})
+        self.assertIsNotNone(self.ctx.last_synced)
+
+    @patch("agents.services._list_s3_sop_files")
+    def test_sync_calls_with_correct_args(self, mock_sops: MagicMock) -> None:
+        mock_sops.return_value = {}
+
+        sync_project_context(self.ctx.pk)
+
+        mock_sops.assert_called_once_with("s3://bucket/test-corp/projects/my-project/")
+
+    @patch("agents.services._list_s3_sop_files")
+    def test_sync_empty_sops(self, mock_sops: MagicMock) -> None:
+        mock_sops.return_value = {}
+
+        sync_project_context(self.ctx.pk)
+
+        self.ctx.refresh_from_db()
+        self.assertEqual(self.ctx.sops_snapshot, {})
+        self.assertIsNotNone(self.ctx.last_synced)

--- a/mrvn/commons/github.py
+++ b/mrvn/commons/github.py
@@ -1,0 +1,32 @@
+import base64
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API_BASE = "https://api.github.com"
+
+
+def _github_headers(token: str = "") -> dict:
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_readme(repo_owner: str, repo_name: str, token: str = "") -> str:
+    """Fetch README content from GitHub. Returns empty string if not found."""
+    url = f"{GITHUB_API_BASE}/repos/{repo_owner}/{repo_name}/readme"
+    try:
+        response = httpx.get(url, headers=_github_headers(token), timeout=10)
+        if response.status_code == 404:
+            logger.info("No README found for %s/%s", repo_owner, repo_name)
+            return ""
+        response.raise_for_status()
+        data = response.json()
+        encoded = data.get("content", "")
+        return base64.b64decode(encoded).decode("utf-8")
+    except Exception as exc:
+        logger.warning("Failed to fetch README for %s/%s: %s", repo_owner, repo_name, exc)
+        return ""

--- a/mrvn/memory/migrations/0005_session_project_context_customer.py
+++ b/mrvn/memory/migrations/0005_session_project_context_customer.py
@@ -1,0 +1,37 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0003_customer_github_token"),
+        ("agents", "0007_project_context"),
+        ("memory", "0004_improve_hnsw_parameters"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="session",
+            name="project_context",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="sessions",
+                to="agents.projectcontext",
+            ),
+        ),
+        migrations.AddField(
+            model_name="session",
+            name="customer",
+            field=models.ForeignKey(
+                blank=True,
+                db_index=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="sessions",
+                to="accounts.customer",
+            ),
+        ),
+    ]

--- a/mrvn/memory/models.py
+++ b/mrvn/memory/models.py
@@ -49,6 +49,23 @@ class Session(TimestampedModel):
         related_name="sessions",
     )
 
+    project_context = models.ForeignKey(
+        "agents.ProjectContext",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="sessions",
+    )
+
+    customer = models.ForeignKey(
+        "accounts.Customer",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="sessions",
+        db_index=True,
+    )
+
     is_active = models.BooleanField(default=True)
 
     # Session metadata (context window info, token counts, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     # Production server
     "gunicorn>=23.0.0",
     "httpx>=0.27.0",  # HTTP client for validations
+    "boto3>=1.35.0",  # AWS S3 access for SOP sync
     # API
     "djangorestframework>=3.15.0",
     # Vector search for memory

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.73"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8b/d00575be514744ca4839e7d85bf4a8a3c7b6b4574433291e58d14c68ae09/boto3-1.42.73.tar.gz", hash = "sha256:d37b58d6cd452ca808dd6823ae19ca65b6244096c5125ef9052988b337298bae", size = 112775, upload-time = "2026-03-20T19:39:52.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/05/1fcf03d90abaa3d0b42a6bfd10231dd709493ecbacf794aa2eea5eae6841/boto3-1.42.73-py3-none-any.whl", hash = "sha256:1f81b79b873f130eeab14bb556417a7c66d38f3396b7f2fe3b958b3f9094f455", size = 140556, upload-time = "2026-03-20T19:39:50.298Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.73"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/23/0c88ca116ef63b1ae77c901cd5d2095d22a8dbde9e80df74545db4a061b4/botocore-1.42.73.tar.gz", hash = "sha256:575858641e4949aaf2af1ced145b8524529edf006d075877af6b82ff96ad854c", size = 15008008, upload-time = "2026-03-20T19:39:40.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/65/971f3d55015f4d133a6ff3ad74cd39f4b8dd8f53f7775a3c2ad378ea5145/botocore-1.42.73-py3-none-any.whl", hash = "sha256:7b62e2a12f7a1b08eb7360eecd23bb16fe3b7ab7f5617cf91b25476c6f86a0fe", size = 14681861, upload-time = "2026-03-20T19:39:35.341Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +511,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -580,6 +617,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "boto3" },
     { name = "django" },
     { name = "django-postgres-extra" },
     { name = "djangorestframework" },
@@ -611,6 +649,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "boto3", specifier = ">=1.35.0" },
     { name = "django", specifier = ">=5.2.8,<5.3" },
     { name = "django-postgres-extra", specifier = ">=2.0.0" },
     { name = "djangorestframework", specifier = ">=3.15.0" },
@@ -1215,6 +1254,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
     { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Addresses review comments from #21 and rebases onto `main` (after #15 merged).

- **Remove `repo_owner`/`repo_name`** from `ProjectContext` — owner is derived from `customer.github_org`; a GitHub project spans multiple repos so `repo_name` isn't appropriate
- **Move GitHub helpers** (`_github_headers`, `fetch_readme`) to `commons/github.py` for broader reuse
- **Add `Customer.github_token`** — token is per-organization, not a global app setting
- **`sync_project_context`** now syncs only S3 SOPs (no single-repo README fetch since there's no `repo_name`)
- **Add `Session.project_context` and `Session.customer` FKs** for multi-tenancy
- **Add `boto3` dependency**

Replaces #21. Closes #3.

## Test plan
- [x] `ProjectContext` model creates and enforces `unique_together (customer, project_id)`
- [x] `Session.project_context` FK is nullable
- [x] `sync_project_context()` calls S3 SOP prefix and persists results
- [x] `makemigrations --check` shows no missing migrations
- [x] All imports verified OK