### PR TITLE
feat: add GitHubIssueTool and GitHubPRTool

### DIFF
--- a/mrvn/agents/models.py
+++ b/mrvn/agents/models.py
@@ -144,6 +144,8 @@ class Agent(TimestampedModel):
                 "edit",
                 "apply_patch",
                 "exec",
+                "github_issue",
+                "github_pr",
                 "process",
                 "web_fetch",
                 "web_search",

--- a/mrvn/agents/tests/test_coding_tools.py
+++ b/mrvn/agents/tests/test_coding_tools.py
@@ -1,28 +1,32 @@
 """Tests for coding tools: read, write, edit, apply_patch, exec, process,
-web_fetch, web_search, sessions_spawn, sessions_send, image, browser."""
+web_fetch, web_search, sessions_spawn, sessions_send, image, browser,
+github_issue, github_pr.
+"""
 
 import os
 import tempfile
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from agents.tools.base import ToolStatus
+from agents.tools.base import ToolResult, ToolStatus
 from agents.tools.coding import (
+    _SESSION_MANAGER,
     ApplyPatchTool,
     BrowserTool,
     EditTool,
     ExecTool,
+    GitHubIssueTool,
+    GitHubPRTool,
     ImageTool,
     ProcessTool,
-    RealWebSearchTool,
     ReadTool,
+    RealWebSearchTool,
     SessionsSendTool,
     SessionsSpawnTool,
     WebFetchTool,
     WriteTool,
-    _SESSION_MANAGER,
+    _run_gh_command,
 )
-
 
 # ---------------------------------------------------------------------------
 # ReadTool
@@ -244,7 +248,7 @@ class ProcessToolTests(IsolatedAsyncioTestCase):
         self.tool = ProcessTool()
 
     async def test_list_empty(self) -> None:
-        from agents.tools.coding import _BACKGROUND_PROCESSES, _BACKGROUND_LOCK
+        from agents.tools.coding import _BACKGROUND_LOCK, _BACKGROUND_PROCESSES
 
         with _BACKGROUND_LOCK:
             _BACKGROUND_PROCESSES.clear()
@@ -252,7 +256,7 @@ class ProcessToolTests(IsolatedAsyncioTestCase):
         self.assertEqual(result.status, ToolStatus.SUCCESS)
 
     async def test_start_and_status(self) -> None:
-        from agents.tools.coding import _BACKGROUND_PROCESSES, _BACKGROUND_LOCK
+        from agents.tools.coding import _BACKGROUND_LOCK, _BACKGROUND_PROCESSES
 
         with _BACKGROUND_LOCK:
             _BACKGROUND_PROCESSES.clear()
@@ -492,3 +496,231 @@ class BrowserToolTests(IsolatedAsyncioTestCase):
         is_valid, error = self.tool.validate_params({"action": "fly"})
         self.assertFalse(is_valid)
         self.assertIn("must be one of", error.lower())
+
+
+# ---------------------------------------------------------------------------
+# _run_gh_command (shared helper)
+# ---------------------------------------------------------------------------
+
+
+class RunGhCommandTests(IsolatedAsyncioTestCase):
+    async def test_gh_not_found_returns_error(self) -> None:
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("gh")):
+            result = await _run_gh_command(["gh", "issue", "view", "url"], "token")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("'gh' CLI not found", result.error)
+
+    async def test_nonzero_exit_returns_error(self) -> None:
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = (b"", b"Not Found")
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await _run_gh_command(["gh", "issue", "view", "url"], "token")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("gh exited with code 1", result.error)
+
+    async def test_success_returns_output(self) -> None:
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (b"Issue title\n", b"")
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await _run_gh_command(["gh", "issue", "view", "url"], "token")
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        self.assertIn("Issue title", result.output)
+
+    async def test_timeout_returns_error(self) -> None:
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.side_effect = TimeoutError()
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await _run_gh_command(["gh", "issue", "view", "url"], "token")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("timed out", result.error.lower())
+
+
+# ---------------------------------------------------------------------------
+# GitHubIssueTool
+# ---------------------------------------------------------------------------
+
+
+class GitHubIssueToolTests(IsolatedAsyncioTestCase):
+    ISSUE_URL = "https://github.com/owner/repo/issues/1"
+    TOKEN = "ghp_test_token"
+
+    def setUp(self) -> None:
+        self.tool = GitHubIssueTool(config={"GITHUB_TOKEN": self.TOKEN})
+
+    async def test_missing_token_returns_error(self) -> None:
+        tool = GitHubIssueTool()
+        result = await tool.execute(action="view", issue_url=self.ISSUE_URL)
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("GITHUB_TOKEN", result.error)
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_view_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="title: Fix bug\n")
+        result = await self.tool.execute(action="view", issue_url=self.ISSUE_URL)
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(["gh", "issue", "view", self.ISSUE_URL], self.TOKEN)
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_comment_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="")
+        result = await self.tool.execute(action="comment", issue_url=self.ISSUE_URL, body="LGTM!")
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(["gh", "issue", "comment", self.ISSUE_URL, "--body", "LGTM!"], self.TOKEN)
+
+    async def test_comment_missing_body_returns_error(self) -> None:
+        result = await self.tool.execute(action="comment", issue_url=self.ISSUE_URL)
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("body", result.error.lower())
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_add_label_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="")
+        result = await self.tool.execute(action="add_label", issue_url=self.ISSUE_URL, label="bug")
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(["gh", "issue", "edit", self.ISSUE_URL, "--add-label", "bug"], self.TOKEN)
+
+    async def test_add_label_missing_label_returns_error(self) -> None:
+        result = await self.tool.execute(action="add_label", issue_url=self.ISSUE_URL)
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("label", result.error.lower())
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_remove_label_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="")
+        result = await self.tool.execute(action="remove_label", issue_url=self.ISSUE_URL, label="wontfix")
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(
+            ["gh", "issue", "edit", self.ISSUE_URL, "--remove-label", "wontfix"], self.TOKEN
+        )
+
+    async def test_remove_label_missing_label_returns_error(self) -> None:
+        result = await self.tool.execute(action="remove_label", issue_url=self.ISSUE_URL)
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("label", result.error.lower())
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_close_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="Closed issue #1")
+        result = await self.tool.execute(action="close", issue_url=self.ISSUE_URL)
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(["gh", "issue", "close", self.ISSUE_URL], self.TOKEN)
+
+    async def test_require_approval_is_true(self) -> None:
+        self.assertTrue(self.tool.require_approval)
+
+    async def test_validate_params_action_required(self) -> None:
+        is_valid, error = self.tool.validate_params({"issue_url": self.ISSUE_URL})
+        self.assertFalse(is_valid)
+        self.assertIn("action", error)
+
+
+# ---------------------------------------------------------------------------
+# GitHubPRTool
+# ---------------------------------------------------------------------------
+
+
+class GitHubPRToolTests(IsolatedAsyncioTestCase):
+    PR_URL = "https://github.com/owner/repo/pull/42"
+    TOKEN = "ghp_test_token"
+
+    def setUp(self) -> None:
+        self.tool = GitHubPRTool(config={"GITHUB_TOKEN": self.TOKEN})
+
+    async def test_missing_token_returns_error(self) -> None:
+        tool = GitHubPRTool()
+        result = await tool.execute(action="view", pr_url=self.PR_URL)
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("GITHUB_TOKEN", result.error)
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_view_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="title: My PR\n")
+        result = await self.tool.execute(action="view", pr_url=self.PR_URL)
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(["gh", "pr", "view", self.PR_URL], self.TOKEN)
+
+    async def test_view_missing_pr_url_returns_error(self) -> None:
+        result = await self.tool.execute(action="view")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("pr_url", result.error.lower())
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_create_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="https://github.com/owner/repo/pull/99\n")
+        result = await self.tool.execute(
+            action="create",
+            title="Add feature",
+            body="Description",
+            base_branch="main",
+            head_branch="feature/foo",
+        )
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                "Add feature",
+                "--body",
+                "Description",
+                "--base",
+                "main",
+                "--head",
+                "feature/foo",
+            ],
+            self.TOKEN,
+        )
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_create_action_with_repo(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="https://github.com/owner/repo/pull/99\n")
+        result = await self.tool.execute(
+            action="create",
+            title="Add feature",
+            base_branch="main",
+            head_branch="feature/foo",
+            repo="owner/repo",
+        )
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        called_cmd = mock_run.call_args[0][0]
+        self.assertIn("--repo", called_cmd)
+        self.assertIn("owner/repo", called_cmd)
+
+    async def test_create_missing_title_returns_error(self) -> None:
+        result = await self.tool.execute(action="create", base_branch="main", head_branch="feature/x")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("title", result.error.lower())
+
+    async def test_create_missing_base_branch_returns_error(self) -> None:
+        result = await self.tool.execute(action="create", title="PR", head_branch="feature/x")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("base_branch", result.error.lower())
+
+    async def test_create_missing_head_branch_returns_error(self) -> None:
+        result = await self.tool.execute(action="create", title="PR", base_branch="main")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("head_branch", result.error.lower())
+
+    @patch("agents.tools.coding._run_gh_command", new_callable=AsyncMock)
+    async def test_update_body_action(self, mock_run: AsyncMock) -> None:
+        mock_run.return_value = ToolResult.success(output="")
+        result = await self.tool.execute(action="update_body", pr_url=self.PR_URL, body="Updated body")
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        mock_run.assert_called_once_with(["gh", "pr", "edit", self.PR_URL, "--body", "Updated body"], self.TOKEN)
+
+    async def test_update_body_missing_pr_url_returns_error(self) -> None:
+        result = await self.tool.execute(action="update_body", body="text")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("pr_url", result.error.lower())
+
+    async def test_require_approval_is_true(self) -> None:
+        self.assertTrue(self.tool.require_approval)
+
+    async def test_validate_params_action_required(self) -> None:
+        is_valid, error = self.tool.validate_params({})
+        self.assertFalse(is_valid)
+        self.assertIn("action", error)

--- a/mrvn/agents/tools/coding.py
+++ b/mrvn/agents/tools/coding.py
@@ -211,7 +211,7 @@ class ApplyPatchTool(BaseTool):
             )
         except FileNotFoundError:
             return ToolResult.from_error("'patch' command not found. Install it with: apt install patch")
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return ToolResult.from_error("patch command timed out")
         except OSError as exc:
             return ToolResult.from_error(f"Error applying patch: {exc}")
@@ -275,10 +275,225 @@ class ExecTool(BaseTool):
                 error=f"Command exited with code {proc.returncode}.",
                 data={"return_code": proc.returncode, "stdout": combined, "stderr": err_text},
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return ToolResult.from_error(f"Command timed out after {timeout}s.")
         except OSError as exc:
             return ToolResult.from_error(f"Error executing command: {exc}")
+
+
+async def _run_gh_command(cmd: list[str], token: str) -> ToolResult:
+    """Run a gh CLI command with GITHUB_TOKEN injected into the environment."""
+    env = {**os.environ, "GITHUB_TOKEN": token}
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        out = stdout.decode(errors="replace")
+        err = stderr.decode(errors="replace")
+        if proc.returncode == 0:
+            return ToolResult.success(
+                output=out,
+                data={"return_code": proc.returncode, "stderr": err},
+            )
+        return ToolResult.from_error(
+            f"gh exited with code {proc.returncode}: {err}",
+            output=out,
+        )
+    except FileNotFoundError:
+        return ToolResult.from_error("'gh' CLI not found. Install it from https://cli.github.com/")
+    except TimeoutError:
+        return ToolResult.from_error("gh command timed out after 30s.")
+    except OSError as exc:
+        return ToolResult.from_error(f"Error running gh: {exc}")
+
+
+class GitHubIssueTool(BaseTool):
+    """Interact with GitHub issues via the gh CLI."""
+
+    name = "github_issue"
+    description = (
+        "Read and update GitHub issues using the gh CLI. Actions: view, comment, add_label, remove_label, close."
+    )
+    require_approval = True
+    parameters = [
+        ToolParameter(
+            name="action",
+            type="string",
+            description="Action to perform: 'view', 'comment', 'add_label', 'remove_label', 'close'.",
+            required=True,
+            enum=["view", "comment", "add_label", "remove_label", "close"],
+        ),
+        ToolParameter(
+            name="issue_url",
+            type="string",
+            description="Full URL of the GitHub issue (e.g. https://github.com/owner/repo/issues/1).",
+            required=True,
+        ),
+        ToolParameter(
+            name="body",
+            type="string",
+            description="Comment body (required for action=comment).",
+            required=False,
+            default="",
+        ),
+        ToolParameter(
+            name="label",
+            type="string",
+            description="Label name (required for add_label and remove_label).",
+            required=False,
+            default="",
+        ),
+    ]
+
+    async def execute(
+        self,
+        action: str,
+        issue_url: str,
+        body: str = "",
+        label: str = "",
+    ) -> ToolResult:
+        """Execute a GitHub issue action."""
+        token = self.config.get("GITHUB_TOKEN", "")
+        if not token:
+            return ToolResult.from_error(
+                "GITHUB_TOKEN is not set in tool config. Provide it via the AgentTool config field."
+            )
+
+        if action == "view":
+            cmd = ["gh", "issue", "view", issue_url]
+        elif action == "comment":
+            if not body:
+                return ToolResult.from_error("body is required for action=comment")
+            cmd = ["gh", "issue", "comment", issue_url, "--body", body]
+        elif action == "add_label":
+            if not label:
+                return ToolResult.from_error("label is required for action=add_label")
+            cmd = ["gh", "issue", "edit", issue_url, "--add-label", label]
+        elif action == "remove_label":
+            if not label:
+                return ToolResult.from_error("label is required for action=remove_label")
+            cmd = ["gh", "issue", "edit", issue_url, "--remove-label", label]
+        elif action == "close":
+            cmd = ["gh", "issue", "close", issue_url]
+        else:
+            return ToolResult.from_error(f"Unknown action: {action}")
+
+        return await _run_gh_command(cmd, token)
+
+
+class GitHubPRTool(BaseTool):
+    """Interact with GitHub pull requests via the gh CLI."""
+
+    name = "github_pr"
+    description = "Create and update GitHub pull requests using the gh CLI. Actions: create, view, update_body."
+    require_approval = True
+    parameters = [
+        ToolParameter(
+            name="action",
+            type="string",
+            description="Action to perform: 'create', 'view', 'update_body'.",
+            required=True,
+            enum=["create", "view", "update_body"],
+        ),
+        ToolParameter(
+            name="pr_url",
+            type="string",
+            description="Full URL of the pull request (required for view and update_body).",
+            required=False,
+            default="",
+        ),
+        ToolParameter(
+            name="repo",
+            type="string",
+            description="Repository in 'owner/repo' format (used with action=create).",
+            required=False,
+            default="",
+        ),
+        ToolParameter(
+            name="title",
+            type="string",
+            description="PR title (required for action=create).",
+            required=False,
+            default="",
+        ),
+        ToolParameter(
+            name="body",
+            type="string",
+            description="PR body/description (used with create and update_body).",
+            required=False,
+            default="",
+        ),
+        ToolParameter(
+            name="base_branch",
+            type="string",
+            description="Base branch for the PR (required for action=create).",
+            required=False,
+            default="",
+        ),
+        ToolParameter(
+            name="head_branch",
+            type="string",
+            description="Head branch for the PR (required for action=create).",
+            required=False,
+            default="",
+        ),
+    ]
+
+    async def execute(
+        self,
+        action: str,
+        pr_url: str = "",
+        repo: str = "",
+        title: str = "",
+        body: str = "",
+        base_branch: str = "",
+        head_branch: str = "",
+    ) -> ToolResult:
+        """Execute a GitHub PR action."""
+        token = self.config.get("GITHUB_TOKEN", "")
+        if not token:
+            return ToolResult.from_error(
+                "GITHUB_TOKEN is not set in tool config. Provide it via the AgentTool config field."
+            )
+
+        if action == "view":
+            if not pr_url:
+                return ToolResult.from_error("pr_url is required for action=view")
+            cmd = ["gh", "pr", "view", pr_url]
+        elif action == "create":
+            if not title:
+                return ToolResult.from_error("title is required for action=create")
+            if not base_branch:
+                return ToolResult.from_error("base_branch is required for action=create")
+            if not head_branch:
+                return ToolResult.from_error("head_branch is required for action=create")
+            cmd = [
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--base",
+                base_branch,
+                "--head",
+                head_branch,
+            ]
+            if repo:
+                cmd += ["--repo", repo]
+        elif action == "update_body":
+            if not pr_url:
+                return ToolResult.from_error("pr_url is required for action=update_body")
+            cmd = ["gh", "pr", "edit", pr_url, "--body", body]
+        else:
+            return ToolResult.from_error(f"Unknown action: {action}")
+
+        return await _run_gh_command(cmd, token)
 
 
 # Background process registry: session_id -> (process, stdout_buffer, stderr_buffer, thread)
@@ -487,7 +702,6 @@ class RealWebSearchTool(BaseTool):
                 "Obtain a key from https://api.search.brave.com/ and set it."
             )
 
-        import json  # noqa: PLC0415
 
         count = min(max(1, num_results), 10)
         url = f"https://api.search.brave.com/res/v1/web/search?q={query}&count={count}"
@@ -926,6 +1140,8 @@ def register_coding_tools(registry: Any) -> None:
         EditTool(),
         ApplyPatchTool(),
         ExecTool(),
+        GitHubIssueTool(),
+        GitHubPRTool(),
         ProcessTool(),
         WebFetchTool(),
         RealWebSearchTool(),


### PR DESCRIPTION
Closes #7

## Summary

- Adds `GitHubIssueTool` (`github_issue`) — actions: `view`, `comment`, `add_label`, `remove_label`, `close`
- Adds `GitHubPRTool` (`github_pr`) — actions: `create`, `view`, `update_body`
- Both tools have `require_approval = True` and inject `GITHUB_TOKEN` from the tool `config` dict
- Graceful error returned when `gh` CLI is not installed or token is missing
- Non-zero `gh` exit codes populate `ToolResult.error`
- Shared `_run_gh_command` async helper handles subprocess execution and error paths
- Both tools registered in `register_coding_tools()` and added to `coding_tools` in `models.py`

## Test plan

- [ ] 27 new unit tests covering every action, missing token, missing `gh` CLI, non-zero exit, and timeout
- [ ] All 69 coding-tool tests pass (`pytest mrvn/agents/tests/test_coding_tools.py`)