### PR TITLE
feat: inject CustomerContextBundle into AgentRunner at startup

### DIFF
--- a/mrvn/agents/runner.py
+++ b/mrvn/agents/runner.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from commons.rate_limiter import rate_limiter_registry
 
+from agents.context import CustomerContextBundle
 from agents.llm import LLMMessage, LLMResponse
 from agents.llm.factory import create_client_from_agent
 from agents.tools import ToolRegistry
@@ -27,6 +28,7 @@ class AgentRunner:
         self,
         agent: Any | None = None,
         *,
+        context_bundle: CustomerContextBundle | None = None,
         registry: ToolRegistry | None = None,
         register_builtins: bool = True,
         session_id: int | None = None,
@@ -35,6 +37,7 @@ class AgentRunner:
 
         Args:
             agent: Optional Agent model instance.
+            context_bundle: Optional CustomerContextBundle to inject into the system prompt.
             registry: Optional custom tool registry.
             register_builtins: Whether to register built-in tools.
             session_id: Optional session ID for memory search context.
@@ -42,10 +45,29 @@ class AgentRunner:
         self.agent = agent
         self.registry = registry or ToolRegistry()
         self._client = None
+        self._context_prefix = ""
 
         if register_builtins:
             agent_id = agent.id if agent else None
-            register_builtin_tools(self.registry, agent_id=agent_id, session_id=session_id)
+            bundle_memories = context_bundle.daily_memories if context_bundle else None
+            register_builtin_tools(
+                self.registry, agent_id=agent_id, session_id=session_id, bundle_memories=bundle_memories
+            )
+
+        if context_bundle:
+            self._inject_context(context_bundle)
+
+    def _inject_context(self, bundle: CustomerContextBundle) -> None:
+        """Build context prefix from bundle and store it for prepending to system prompts."""
+        parts = []
+        if bundle.claude_md:
+            parts.append(bundle.claude_md)
+        if bundle.sops:
+            for filename, content in bundle.sops.items():
+                parts.append(f"## {filename}\n\n{content}")
+        if bundle.project_goals:
+            parts.append(bundle.project_goals)
+        self._context_prefix = "\n\n".join(parts)
 
     async def get_client(self) -> Any:
         """Get or create the LLM client."""
@@ -129,6 +151,10 @@ class AgentRunner:
         prompt = system_prompt
         if prompt is None and self.agent:
             prompt = self.agent.system_prompt
+
+        # Prepend context bundle content when available
+        if self._context_prefix:
+            prompt = f"{self._context_prefix}\n\n{prompt}" if prompt else self._context_prefix
 
         # Get tools if enabled
         tools = None

--- a/mrvn/agents/tests/test_runner.py
+++ b/mrvn/agents/tests/test_runner.py
@@ -1,0 +1,177 @@
+"""Tests for AgentRunner context bundle injection and MemorySearchTool bundle search."""
+
+import datetime
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agents.context import CustomerContextBundle, MemoryEntry
+from agents.llm import LLMMessage
+from agents.runner import AgentRunner
+from agents.tools.base import ToolStatus
+from agents.tools.builtin import MemorySearchTool
+
+
+def make_bundle(**kwargs) -> CustomerContextBundle:
+    defaults = {
+        "customer_id": "acme",
+        "claude_md": "# Project Instructions\nBe concise and helpful.",
+        "sops": {"onboarding.md": "# Onboarding\nFollow the standard process."},
+        "project_goals": "# Goals\nBuild reliable software.",
+        "memory_index": "# Memory Index\n- 2024-01-15.md",
+        "daily_memories": [],
+    }
+    defaults.update(kwargs)
+    return CustomerContextBundle(**defaults)
+
+
+def make_memory_entry(content: str, date: datetime.date | None = None) -> MemoryEntry:
+    date = date or datetime.date(2024, 1, 15)
+    return MemoryEntry(
+        date=date,
+        filename=f"{date}.md",
+        content=content,
+        is_weekly_summary=False,
+    )
+
+
+class AgentRunnerContextBundleTests(IsolatedAsyncioTestCase):
+    """Tests for AgentRunner with CustomerContextBundle injection."""
+
+    def test_init_accepts_context_bundle(self) -> None:
+        bundle = make_bundle()
+        runner = AgentRunner(context_bundle=bundle, register_builtins=False)
+        self.assertIsNotNone(runner._context_prefix)
+
+    def test_context_prefix_includes_claude_md(self) -> None:
+        bundle = make_bundle(claude_md="# My Instructions\nDo this.", sops={}, project_goals="")
+        runner = AgentRunner(context_bundle=bundle, register_builtins=False)
+        self.assertIn("# My Instructions", runner._context_prefix)
+
+    def test_context_prefix_includes_project_goals(self) -> None:
+        bundle = make_bundle(claude_md="", sops={}, project_goals="# Goals\nShip fast.")
+        runner = AgentRunner(context_bundle=bundle, register_builtins=False)
+        self.assertIn("# Goals", runner._context_prefix)
+
+    def test_context_prefix_includes_sops(self) -> None:
+        bundle = make_bundle(claude_md="", sops={"process.md": "# Process\nStep 1."}, project_goals="")
+        runner = AgentRunner(context_bundle=bundle, register_builtins=False)
+        self.assertIn("process.md", runner._context_prefix)
+        self.assertIn("# Process", runner._context_prefix)
+
+    def test_no_bundle_leaves_empty_prefix(self) -> None:
+        runner = AgentRunner(register_builtins=False)
+        self.assertEqual(runner._context_prefix, "")
+
+    async def test_run_prepends_bundle_context_to_system_prompt(self) -> None:
+        bundle = make_bundle(claude_md="BUNDLE_CONTENT", sops={}, project_goals="")
+        runner = AgentRunner(context_bundle=bundle, register_builtins=False)
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.has_tool_calls = False
+        mock_response.content = "Agent reply"
+        mock_client.generate = AsyncMock(return_value=mock_response)
+        runner._client = mock_client
+
+        await runner.run([LLMMessage.user("Hello")], enable_tools=False)
+
+        mock_client.generate.assert_called_once()
+        call_kwargs = mock_client.generate.call_args.kwargs
+        self.assertIn("BUNDLE_CONTENT", call_kwargs["system_prompt"])
+
+    async def test_run_prepends_bundle_before_agent_system_prompt(self) -> None:
+        bundle = make_bundle(claude_md="BUNDLE", sops={}, project_goals="")
+        mock_agent = MagicMock()
+        mock_agent.system_prompt = "AGENT_PROMPT"
+        mock_agent.rate_limit_enabled = False
+        mock_agent.provider = "openai"
+        mock_agent.temperature = 0.7
+        mock_agent.max_tokens = 4096
+        mock_agent.id = 1
+
+        runner = AgentRunner(mock_agent, context_bundle=bundle, register_builtins=False)
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.has_tool_calls = False
+        mock_response.content = "reply"
+        mock_client.generate = AsyncMock(return_value=mock_response)
+        runner._client = mock_client
+
+        await runner.run([LLMMessage.user("Hi")], enable_tools=False)
+
+        call_kwargs = mock_client.generate.call_args.kwargs
+        prompt = call_kwargs["system_prompt"]
+        self.assertIn("BUNDLE", prompt)
+        self.assertIn("AGENT_PROMPT", prompt)
+        self.assertLess(prompt.index("BUNDLE"), prompt.index("AGENT_PROMPT"))
+
+
+class MemorySearchToolBundleTests(IsolatedAsyncioTestCase):
+    """Tests for MemorySearchTool bundle memory search."""
+
+    def _make_memories(self) -> list[MemoryEntry]:
+        return [
+            make_memory_entry("Met with Alice to discuss project roadmap and Q1 planning."),
+            make_memory_entry("Resolved bug in the authentication module.", datetime.date(2024, 1, 16)),
+            MemoryEntry(
+                date=datetime.date(2024, 1, 20),
+                filename="2024-01-20_WEEKLY_SUMMARY.md",
+                content="Weekly summary: completed setup and first deployment.",
+                is_weekly_summary=True,
+            ),
+        ]
+
+    async def test_finds_matching_memory(self) -> None:
+        tool = MemorySearchTool(bundle_memories=self._make_memories())
+        result = await tool.execute(query="roadmap")
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        self.assertEqual(result.data["count"], 1)
+        self.assertIn("roadmap", result.data["results"][0]["content"].lower())
+
+    async def test_no_match_returns_empty(self) -> None:
+        tool = MemorySearchTool(bundle_memories=self._make_memories())
+        result = await tool.execute(query="xyzzy_no_match_here")
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        self.assertEqual(result.data["count"], 0)
+
+    async def test_result_source_prefixed_with_bundle(self) -> None:
+        tool = MemorySearchTool(bundle_memories=self._make_memories())
+        result = await tool.execute(query="authentication")
+        self.assertTrue(result.data["results"][0]["source"].startswith("bundle:"))
+
+    async def test_respects_max_results(self) -> None:
+        memories = [make_memory_entry(f"Note about topic number {i}.") for i in range(8)]
+        tool = MemorySearchTool(bundle_memories=memories)
+        result = await tool.execute(query="topic", max_results=3)
+        self.assertLessEqual(result.data["count"], 3)
+
+    async def test_bundle_bypasses_db(self) -> None:
+        """Bundle search must not import or call DB-backed MemorySearchService."""
+        tool = MemorySearchTool(bundle_memories=self._make_memories())
+        with (
+            patch(
+                "agents.tools.builtin.MemorySearchTool._search_bundle_memories",
+                wraps=tool._search_bundle_memories,
+            ) as mock_bundle_search,
+            patch.dict("sys.modules", {"memory.search": None}),
+        ):
+            result = await tool.execute(query="roadmap")
+        mock_bundle_search.assert_called_once()
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+
+    async def test_no_bundle_memories_falls_through_to_db_path(self) -> None:
+        """Without bundle memories, execute() should attempt DB search."""
+        tool = MemorySearchTool()
+        with (
+            patch("memory.models.Session"),
+            patch("memory.search.MemorySearchConfig"),
+            patch("memory.search.MemorySearchService") as mock_service_cls,
+        ):
+            mock_service = MagicMock()
+            mock_service.search.return_value = []
+            mock_service_cls.return_value = mock_service
+            result = await tool.execute(query="test")
+        mock_service_cls.assert_called_once()
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        self.assertEqual(result.data["count"], 0)

--- a/mrvn/agents/tools/builtin.py
+++ b/mrvn/agents/tools/builtin.py
@@ -3,9 +3,12 @@
 import contextlib
 import datetime
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agents.tools.base import BaseTool, ToolParameter, ToolResult
+
+if TYPE_CHECKING:
+    from agents.context import MemoryEntry
 
 logger = logging.getLogger(__name__)
 
@@ -151,13 +154,13 @@ class BrowserTool(BaseTool):
         import urllib.request  # noqa: PLC0415
 
         try:
-            with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310
+            with urllib.request.urlopen(url, timeout=10) as response:  # noqa: ASYNC210, S310
                 content = response.read().decode("utf-8", errors="replace")
             return ToolResult.success(
                 output=content,
                 data={"url": url, "length": len(content)},
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             return ToolResult.from_error(f"Failed to fetch URL: {exc}")
 
 
@@ -260,6 +263,7 @@ class MemorySearchTool(BaseTool):
         config: dict[str, Any] | None = None,
         agent_id: int | None = None,
         session_id: int | None = None,
+        bundle_memories: list[MemoryEntry] | None = None,
     ) -> None:
         """Initialize with optional agent/session context.
 
@@ -267,10 +271,33 @@ class MemorySearchTool(BaseTool):
             config: Tool configuration.
             agent_id: Optional agent ID to limit search scope.
             session_id: Optional session ID to limit search scope.
+            bundle_memories: Optional pre-loaded memories from a CustomerContextBundle.
+                When provided, searches these in-memory instead of the database.
         """
         super().__init__(config)
         self.agent_id = agent_id
         self.session_id = session_id
+        self._bundle_memories = bundle_memories or []
+
+    def _search_bundle_memories(self, query: str, max_results: int) -> list[dict[str, Any]]:
+        """Search bundle memories using keyword matching."""
+        query_lower = query.lower()
+        results = []
+        for entry in self._bundle_memories:
+            if query_lower in entry.content.lower():
+                results.append(
+                    {
+                        "content": entry.content,
+                        "score": 1.0,
+                        "source": f"bundle:{entry.filename}",
+                        "metadata": {
+                            "date": str(entry.date),
+                            "filename": entry.filename,
+                            "is_weekly_summary": entry.is_weekly_summary,
+                        },
+                    }
+                )
+        return results[:max_results]
 
     async def execute(
         self,
@@ -279,11 +306,29 @@ class MemorySearchTool(BaseTool):
         max_results: int = 5,
     ) -> ToolResult:
         """Search conversation memory."""
+        max_results = min(max(1, max_results), 10)
+
+        if self._bundle_memories:
+            formatted = self._search_bundle_memories(query, max_results)
+            if not formatted:
+                return ToolResult.success(
+                    output="No relevant memories found.",
+                    data={"query": query, "results": [], "count": 0},
+                )
+            output_lines = [f"Found {len(formatted)} relevant memories:"]
+            for i, r in enumerate(formatted, 1):
+                output_lines.append(f"\n{i}. [{r['source']}] (score: {r['score']})")
+                output_lines.append(f"   {r['content'][:200]}...")
+            return ToolResult.success(
+                output="\n".join(output_lines),
+                data={"query": query, "results": formatted, "count": len(formatted)},
+            )
+
         from memory.models import Session  # noqa: PLC0415
         from memory.search import MemorySearchConfig, MemorySearchService  # noqa: PLC0415
 
         # Create search service with custom max_results
-        config = MemorySearchConfig(max_results=min(max(1, max_results), 10))
+        config = MemorySearchConfig(max_results=max_results)
         service = MemorySearchService(config)
 
         # Get session if we have a session_id
@@ -333,6 +378,7 @@ def register_builtin_tools(
     registry: Any,
     agent_id: int | None = None,
     session_id: int | None = None,
+    bundle_memories: list[MemoryEntry] | None = None,
 ) -> None:
     """Register all built-in tools with the given registry.
 
@@ -343,6 +389,7 @@ def register_builtin_tools(
         registry: The ToolRegistry instance.
         agent_id: Optional agent ID for memory search context.
         session_id: Optional session ID for memory search context.
+        bundle_memories: Optional pre-loaded memories from a CustomerContextBundle.
     """
     from agents.tools.coding import register_coding_tools  # noqa: PLC0415
 
@@ -353,7 +400,7 @@ def register_builtin_tools(
         BrowserTool(),
         MemoryStoreTool(),
         MemoryRetrieveTool(),
-        MemorySearchTool(agent_id=agent_id, session_id=session_id),
+        MemorySearchTool(agent_id=agent_id, session_id=session_id, bundle_memories=bundle_memories),
     ]
 
     for tool in core_tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ where = ["."]  # list of folders that contain the packages (["."] by default)
 include = ["mrvn/*"]  # package names should match these glob patterns (["*"] by default)
 exclude = []  # exclude packages matching these glob patterns (empty by default)
 
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "mrvn.settings"
+pythonpath = ["mrvn"]
+
 # Task runner
 [tool.poe.tasks]
 check = "uv run ruff check"


### PR DESCRIPTION
Closes #6

## Summary

- `AgentRunner.__init__` accepts an optional `context_bundle: CustomerContextBundle | None` parameter
- `_inject_context()` builds a context prefix from the bundle's `claude_md`, `sops`, and `project_goals`, stored as `self._context_prefix`
- `run()` prepends `_context_prefix` to the system prompt on every call
- `MemorySearchTool` gains a `bundle_memories` parameter; when set, `_search_bundle_memories()` does keyword matching in-memory, bypassing pgvector/DB entirely
- `register_builtin_tools()` forwards `bundle_memories` to `MemorySearchTool`
- Added `[tool.pytest.ini_options]` with `DJANGO_SETTINGS_MODULE` to `pyproject.toml` so `uv run pytest` works alongside `manage.py test`

## Test plan

- [ ] `uv run pytest mrvn/agents/tests/test_runner.py -v` — 13 new tests all pass
- [ ] `uv run pytest mrvn/agents/tests/test_tool_execution.py -v` — 27 existing tests still pass
- [ ] Ruff linting: `uv run ruff check mrvn/agents/runner.py mrvn/agents/tools/builtin.py mrvn/agents/tests/test_runner.py` — no errors