### PR TITLE
feat: add S3MemoryWriteTool

### DIFF
--- a/mrvn/agents/models.py
+++ b/mrvn/agents/models.py
@@ -154,6 +154,7 @@ class Agent(TimestampedModel):
                 "memory_store",
                 "memory_retrieve",
                 "memory_search",
+                "s3_memory_write",
             }
             return [t for t in available_tools if t in coding_tools]
         if self.tool_profile == ToolProfile.MESSAGING.value:

--- a/mrvn/agents/runner.py
+++ b/mrvn/agents/runner.py
@@ -30,6 +30,7 @@ class AgentRunner:
         registry: ToolRegistry | None = None,
         register_builtins: bool = True,
         session_id: int | None = None,
+        s3_prefix: str = "",
     ) -> None:
         """Initialize the agent runner.
 
@@ -38,6 +39,7 @@ class AgentRunner:
             registry: Optional custom tool registry.
             register_builtins: Whether to register built-in tools.
             session_id: Optional session ID for memory search context.
+            s3_prefix: S3 prefix for the S3MemoryWriteTool (pre-fills context).
         """
         self.agent = agent
         self.registry = registry or ToolRegistry()
@@ -45,7 +47,7 @@ class AgentRunner:
 
         if register_builtins:
             agent_id = agent.id if agent else None
-            register_builtin_tools(self.registry, agent_id=agent_id, session_id=session_id)
+            register_builtin_tools(self.registry, agent_id=agent_id, session_id=session_id, s3_prefix=s3_prefix)
 
     async def get_client(self) -> Any:
         """Get or create the LLM client."""
@@ -55,6 +57,23 @@ class AgentRunner:
             else:
                 raise ValueError("No agent configured")
         return self._client
+
+    def _inject_context(self, s3_prefix: str) -> None:
+        """Pre-fill S3MemoryWriteTool with the customer S3 prefix.
+
+        Call this after construction when the CustomerContextBundle is available.
+        If the tool is already registered it is replaced with a new instance
+        carrying the correct prefix.
+
+        Args:
+            s3_prefix: Full S3 prefix, e.g. 's3://bucket/customers/c-1/projects/repo'.
+        """
+        from agents.tools.s3_memory import S3MemoryWriteTool  # noqa: PLC0415
+
+        tool = S3MemoryWriteTool(s3_prefix=s3_prefix)
+        # Remove stale registration if present, then re-register.
+        self.registry.unregister(tool.name)
+        self.registry.register(tool)
 
     def register_tool(self, tool: Any) -> None:
         """Register a tool with the runner.

--- a/mrvn/agents/tests/test_s3_memory_write_tool.py
+++ b/mrvn/agents/tests/test_s3_memory_write_tool.py
@@ -1,0 +1,122 @@
+"""Unit tests for S3MemoryWriteTool using moto to mock S3."""
+
+import datetime
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+import boto3
+from moto import mock_aws
+
+from agents.tools.base import ToolStatus
+from agents.tools.s3_memory import S3MemoryWriteTool
+
+BUCKET = "test-bucket"
+CUSTOMER_PREFIX = "customers/cust-001"
+REPO_NAME = "my-repo"
+S3_PREFIX = f"s3://{BUCKET}/{CUSTOMER_PREFIX}/projects/{REPO_NAME}"
+
+_MOTO_ENV = {
+    "AWS_ACCESS_KEY_ID": "test",
+    "AWS_SECRET_ACCESS_KEY": "test",
+    "AWS_DEFAULT_REGION": "us-east-1",
+}
+
+
+class S3MemoryWriteToolTests(IsolatedAsyncioTestCase):
+    """Tests for S3MemoryWriteTool.execute() — uses moto to mock S3."""
+
+    async def asyncSetUp(self) -> None:
+        self._mock = mock_aws()
+        self._mock.start()
+        self._env_patcher = patch.dict("os.environ", _MOTO_ENV)
+        self._env_patcher.start()
+        self._settings_patcher = patch("django.conf.settings.S3_ENDPOINT_URL", None)
+        self._settings_patcher.start()
+        self.s3 = boto3.client("s3", region_name="us-east-1")
+        self.s3.create_bucket(Bucket=BUCKET)
+        self.tool = S3MemoryWriteTool(s3_prefix=S3_PREFIX)
+
+    async def asyncTearDown(self) -> None:
+        self._settings_patcher.stop()
+        self._env_patcher.stop()
+        self._mock.stop()
+
+    async def test_execute_creates_daily_file(self) -> None:
+        today = datetime.datetime.now(tz=datetime.UTC).date()
+        result = await self.tool.execute(
+            section_header="## Actions",
+            content="- Updated issue #9\n",
+        )
+
+        self.assertEqual(result.status, ToolStatus.SUCCESS)
+        self.assertIn(today.isoformat(), result.output)
+        self.assertEqual(result.data["date"], today.isoformat())
+
+    async def test_execute_appends_section_header_and_content(self) -> None:
+        today = datetime.datetime.now(tz=datetime.UTC).date()
+        await self.tool.execute(
+            section_header="## 2026-03-18 14:30:00 Actions",
+            content="- Did something\n",
+        )
+
+        key = f"{CUSTOMER_PREFIX}/projects/{REPO_NAME}/memory/{today.year}/{today.isoformat()}.md"
+        body = self.s3.get_object(Bucket=BUCKET, Key=key)["Body"].read().decode()
+
+        self.assertIn("## 2026-03-18 14:30:00 Actions", body)
+        self.assertIn("- Did something", body)
+
+    async def test_execute_appends_to_existing_file(self) -> None:
+        today = datetime.datetime.now(tz=datetime.UTC).date()
+        key = f"{CUSTOMER_PREFIX}/projects/{REPO_NAME}/memory/{today.year}/{today.isoformat()}.md"
+        self.s3.put_object(Bucket=BUCKET, Key=key, Body=b"## Earlier Entry\n- old note\n")
+
+        await self.tool.execute(section_header="## Later Entry", content="- new note\n")
+
+        body = self.s3.get_object(Bucket=BUCKET, Key=key)["Body"].read().decode()
+        self.assertIn("## Earlier Entry", body)
+        self.assertIn("## Later Entry", body)
+        self.assertIn("- new note", body)
+
+    async def test_execute_returns_error_when_no_prefix(self) -> None:
+        tool = S3MemoryWriteTool(s3_prefix="")
+        result = await tool.execute(section_header="## Actions", content="content\n")
+        self.assertEqual(result.status, ToolStatus.ERROR)
+        self.assertIn("s3_prefix", result.error)
+
+    async def test_execute_data_contains_filename_and_prefix(self) -> None:
+        today = datetime.datetime.now(tz=datetime.UTC).date()
+        result = await self.tool.execute(section_header="## Header", content="body\n")
+        self.assertEqual(result.data["s3_prefix"], S3_PREFIX)
+        self.assertEqual(result.data["filename"], f"{today.isoformat()}.md")
+
+
+class S3MemoryWriteToolProfileTests(unittest.TestCase):
+    """Tests that S3MemoryWriteTool appears in the expected tool profiles."""
+
+    def test_tool_name(self) -> None:
+        self.assertEqual(S3MemoryWriteTool.name, "s3_memory_write")
+
+    def test_tool_registered_in_coding_profile(self) -> None:
+        from agents.models import Agent, ToolProfile  # noqa: PLC0415
+
+        agent = Agent.__new__(Agent)
+        agent.tool_profile = ToolProfile.CODING.value
+        agent.tools_allow = []
+        agent.tools_deny = []
+
+        all_tools = ["s3_memory_write", "read", "write", "exec"]
+        allowed = agent.get_allowed_tools(all_tools)
+        self.assertIn("s3_memory_write", allowed)
+
+    def test_tool_registered_in_full_profile(self) -> None:
+        from agents.models import Agent, ToolProfile  # noqa: PLC0415
+
+        agent = Agent.__new__(Agent)
+        agent.tool_profile = ToolProfile.FULL.value
+        agent.tools_allow = []
+        agent.tools_deny = []
+
+        all_tools = ["s3_memory_write", "read", "write", "exec"]
+        allowed = agent.get_allowed_tools(all_tools)
+        self.assertIn("s3_memory_write", allowed)

--- a/mrvn/agents/tools/builtin.py
+++ b/mrvn/agents/tools/builtin.py
@@ -333,6 +333,7 @@ def register_builtin_tools(
     registry: Any,
     agent_id: int | None = None,
     session_id: int | None = None,
+    s3_prefix: str = "",
 ) -> None:
     """Register all built-in tools with the given registry.
 
@@ -343,8 +344,10 @@ def register_builtin_tools(
         registry: The ToolRegistry instance.
         agent_id: Optional agent ID for memory search context.
         session_id: Optional session ID for memory search context.
+        s3_prefix: Optional S3 prefix for the S3MemoryWriteTool.
     """
     from agents.tools.coding import register_coding_tools  # noqa: PLC0415
+    from agents.tools.s3_memory import S3MemoryWriteTool  # noqa: PLC0415
 
     core_tools = [
         DateTimeTool(),
@@ -354,6 +357,7 @@ def register_builtin_tools(
         MemoryStoreTool(),
         MemoryRetrieveTool(),
         MemorySearchTool(agent_id=agent_id, session_id=session_id),
+        S3MemoryWriteTool(s3_prefix=s3_prefix),
     ]
 
     for tool in core_tools:

--- a/mrvn/agents/tools/s3_memory.py
+++ b/mrvn/agents/tools/s3_memory.py
@@ -1,0 +1,64 @@
+"""S3-backed memory write tool for agent session notes."""
+
+import datetime
+import logging
+from typing import Any
+
+from agents.context import ContextBundleService, MemoryEntry
+from agents.tools.base import BaseTool, ToolParameter, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+class S3MemoryWriteTool(BaseTool):
+    """Write agent session notes to the daily memory file on S3."""
+
+    name = "s3_memory_write"
+    description = (
+        "Append a markdown block to the daily memory file on S3. "
+        "Use this to persist what you did, decisions made, and issues updated during this session."
+    )
+    parameters = [
+        ToolParameter(
+            name="section_header",
+            type="string",
+            description="Markdown section heading for this entry, e.g. '## 2026-03-18 14:30:00 Actions'.",
+            required=True,
+        ),
+        ToolParameter(
+            name="content",
+            type="string",
+            description="Markdown block to append under the section header.",
+            required=True,
+        ),
+    ]
+
+    def __init__(self, s3_prefix: str = "", config: dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+        self.s3_prefix = s3_prefix
+
+    async def execute(self, section_header: str, content: str) -> ToolResult:
+        if not self.s3_prefix:
+            return ToolResult.from_error("s3_prefix is not configured; cannot write memory.")
+
+        today = datetime.datetime.now(tz=datetime.UTC).date()
+        filename = f"{today.isoformat()}.md"
+        entry_content = f"{section_header}\n{content}\n"
+
+        entry = MemoryEntry(
+            date=today,
+            filename=filename,
+            content=entry_content,
+        )
+
+        try:
+            ContextBundleService().push_memory(self.s3_prefix, entry)
+        except Exception as exc:
+            logger.exception("Failed to write memory entry to S3")
+            return ToolResult.from_error(f"Failed to write memory: {exc}")
+
+        key_hint = f"memory/{today.year}/{filename}"
+        return ToolResult.success(
+            output=f"Memory entry written to {key_hint}.",
+            data={"s3_prefix": self.s3_prefix, "filename": filename, "date": today.isoformat()},
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "poethepoet>=0.34.0",
     "pytest>=9.0.2",
     "pytest-django>=4.12.0",
+    "moto[s3]>=5.1.22",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -603,6 +603,32 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3d/1765accbf753dc1ae52f26a2e2ed2881d78c2eb9322c178e45312472e4a0/moto-5.1.22.tar.gz", hash = "sha256:e5b2c378296e4da50ce5a3c355a1743c8d6d396ea41122f5bb2a40f9b9a8cc0e", size = 8547792, upload-time = "2026-03-08T21:06:43.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4f/8812a01e3e0bd6be3e13b90432fb5c696af9a720af3f00e6eba5ad748345/moto-5.1.22-py3-none-any.whl", hash = "sha256:d9f20ae3cf29c44f93c1f8f06c8f48d5560e5dc027816ef1d0d2059741ffcfbe", size = 6617400, upload-time = "2026-03-08T21:06:41.093Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -638,6 +664,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "moto", extra = ["s3"] },
     { name = "poethepoet" },
     { name = "pyright" },
     { name = "pytest" },
@@ -670,6 +697,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "moto", extras = ["s3"], specifier = ">=5.1.22" },
     { name = "poethepoet", specifier = ">=0.34.0" },
     { name = "pyright", specifier = ">=1.1.396" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -979,6 +1007,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1216,6 +1253,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
 ]
 
 [[package]]
@@ -1647,10 +1698,31 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/43/76ded108b296a49f52de6bac5192ca1c4be84e886f9b5c9ba8427d9694fd/werkzeug-3.1.7.tar.gz", hash = "sha256:fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351", size = 875700, upload-time = "2026-03-24T01:08:07.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl", hash = "sha256:4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f", size = 226295, upload-time = "2026-03-24T01:08:06.133Z" },
+]
+
+[[package]]
 name = "whitenoise"
 version = "6.11.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/95/8c81ec6b6ebcbf8aca2de7603070ccf37dbb873b03f20708e0f7c1664bc6/whitenoise-6.11.0.tar.gz", hash = "sha256:0f5bfce6061ae6611cd9396a8231e088722e4fc67bc13a111be74c738d99375f", size = 26432, upload-time = "2025-09-18T09:16:10.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/e9/4366332f9295fe0647d7d3251ce18f5615fbcb12d02c79a26f8dba9221b3/whitenoise-6.11.0-py3-none-any.whl", hash = "sha256:b2aeb45950597236f53b5342b3121c5de69c8da0109362aee506ce88e022d258", size = 20197, upload-time = "2025-09-18T09:16:09.754Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]


### PR DESCRIPTION
Closes #9

## Summary

- Adds `S3MemoryWriteTool` (`agents/tools/s3_memory.py`) that appends markdown blocks to the daily memory file on S3 using `ContextBundleService.push_memory()`
- The `s3_prefix` is pre-filled at construction time — agents only provide `section_header` and `content`
- `AgentRunner._inject_context(s3_prefix)` allows late-binding the prefix after the `CustomerContextBundle` is resolved
- Tool is registered under both `coding` and `full` profiles
- Unit tests use `moto` to mock S3 (8 tests, no LocalStack dependency)

## Test plan

- [x] `uv run python manage.py test agents.tests.test_s3_memory_write_tool` — all 8 tests pass
- [x] `ruff check` — no new lint errors