### PR TITLE
feat: session transcript replay in AgentRunner

### DIFF
--- a/mrvn/agents/migrations/0008_agent_context_window_messages.py
+++ b/mrvn/agents/migrations/0008_agent_context_window_messages.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("agents", "0007_project_context"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agent",
+            name="context_window_messages",
+            field=models.PositiveIntegerField(
+                default=0,
+                help_text="Number of prior session messages to inject as context on resume (0 = disabled)",
+            ),
+        ),
+    ]

--- a/mrvn/agents/models.py
+++ b/mrvn/agents/models.py
@@ -88,6 +88,12 @@ class Agent(TimestampedModel):
         help_text="Memory search config: max_results, min_score, hybrid_weights, etc.",
     )
 
+    # Session transcript replay
+    context_window_messages = models.PositiveIntegerField(
+        default=0,
+        help_text="Number of prior session messages to inject as context on resume (0 = disabled)",
+    )
+
     # Additional config (stop sequences, etc.)
     config = models.JSONField(default=dict, blank=True)
 

--- a/mrvn/agents/runner.py
+++ b/mrvn/agents/runner.py
@@ -4,13 +4,52 @@ import logging
 from typing import Any
 
 from commons.rate_limiter import rate_limiter_registry
+from memory.models import Message, MessageRole as MemoryMessageRole
 
 from agents.llm import LLMMessage, LLMResponse
+from agents.llm.base import ToolCall
 from agents.llm.factory import create_client_from_agent
 from agents.tools import ToolRegistry
 from agents.tools.builtin import register_builtin_tools
 
 logger = logging.getLogger(__name__)
+
+
+def session_messages_to_llm_messages(records: list[Any]) -> list[LLMMessage]:
+    """Convert a list of memory.Message records to LLMMessage objects.
+
+    System messages are skipped — system prompt is handled separately.
+    Assistant messages reconstruct tool_calls from raw_data if present.
+    Tool result messages use tool_call_id and tool_name from the record.
+
+    Args:
+        records: Ordered list of memory.Message instances.
+
+    Returns:
+        List of LLMMessage objects in the same order.
+    """
+    messages: list[LLMMessage] = []
+    for record in records:
+        if record.role == MemoryMessageRole.USER:
+            messages.append(LLMMessage.user(record.content))
+        elif record.role == MemoryMessageRole.ASSISTANT:
+            tool_calls = None
+            raw_tool_calls = record.raw_data.get("tool_calls") if record.raw_data else None
+            if raw_tool_calls:
+                tool_calls = [
+                    ToolCall(id=tc["id"], name=tc["name"], arguments=tc["arguments"]) for tc in raw_tool_calls
+                ]
+            messages.append(LLMMessage.assistant(record.content, tool_calls))
+        elif record.role == MemoryMessageRole.TOOL:
+            messages.append(
+                LLMMessage.tool_result(
+                    tool_call_id=record.tool_call_id,
+                    content=record.content,
+                    name=record.tool_name or None,
+                )
+            )
+        # Skip system messages — handled via system_prompt parameter
+    return messages
 
 
 class AgentRunner:
@@ -98,10 +137,27 @@ class AgentRunner:
         )
         await limiter.acquire_async()
 
+    async def _load_session_transcript(self, session: Any, n: int) -> list[LLMMessage]:
+        """Load the last N messages from a session and convert to LLMMessage objects.
+
+        Args:
+            session: memory.Session instance.
+            n: Maximum number of messages to load.
+
+        Returns:
+            List of LLMMessage objects in chronological order.
+        """
+        records: list[Any] = []
+        async for record in Message.objects.filter(session=session).order_by("-created_datetime")[:n]:
+            records.append(record)
+        records.reverse()
+        return session_messages_to_llm_messages(records)
+
     async def run(
         self,
         messages: list[LLMMessage],
         *,
+        session: Any | None = None,
         system_prompt: str | None = None,
         enable_tools: bool = True,
         tool_names: list[str] | None = None,
@@ -111,6 +167,7 @@ class AgentRunner:
 
         Args:
             messages: Conversation messages.
+            session: Optional memory.Session instance for transcript replay.
             system_prompt: Optional system prompt override.
             enable_tools: Whether to enable tool calling.
             tool_names: Optional list of tool names to enable.
@@ -121,6 +178,12 @@ class AgentRunner:
         """
         # Apply rate limiting
         await self._check_rate_limit()
+
+        # Inject prior session transcript when configured
+        if session is not None and self.agent is not None and self.agent.context_window_messages > 0:
+            transcript = await self._load_session_transcript(session, self.agent.context_window_messages)
+            if transcript:
+                messages = transcript + messages
 
         # Get client
         client = await self.get_client()

--- a/mrvn/agents/tests/test_runner.py
+++ b/mrvn/agents/tests/test_runner.py
@@ -1,0 +1,189 @@
+"""Tests for AgentRunner transcript replay feature."""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agents.llm.base import LLMMessage, LLMResponse, MessageRole, StopReason
+from agents.runner import AgentRunner, session_messages_to_llm_messages
+
+
+def _make_record(
+    role: str, content: str, *, tool_call_id: str = "", tool_name: str = "", raw_data: dict | None = None
+) -> MagicMock:
+    """Build a mock memory.Message record."""
+    record = MagicMock()
+    record.role = role
+    record.content = content
+    record.tool_call_id = tool_call_id
+    record.tool_name = tool_name
+    record.raw_data = raw_data or {}
+    return record
+
+
+class SessionMessagesToLLMMessagesTests(IsolatedAsyncioTestCase):
+    """Tests for the session_messages_to_llm_messages conversion function."""
+
+    def test_user_message_converted(self) -> None:
+        records = [_make_record("user", "Hello")]
+        result = session_messages_to_llm_messages(records)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].role, MessageRole.USER)
+        self.assertEqual(result[0].content, "Hello")
+
+    def test_assistant_message_converted(self) -> None:
+        records = [_make_record("assistant", "Hi there")]
+        result = session_messages_to_llm_messages(records)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].role, MessageRole.ASSISTANT)
+        self.assertEqual(result[0].content, "Hi there")
+        self.assertIsNone(result[0].tool_calls)
+
+    def test_assistant_message_with_tool_calls_reconstructed(self) -> None:
+        raw = {"tool_calls": [{"id": "tc_1", "name": "calculator", "arguments": {"expression": "2+2"}}]}
+        records = [_make_record("assistant", "", raw_data=raw)]
+        result = session_messages_to_llm_messages(records)
+        self.assertEqual(len(result), 1)
+        self.assertIsNotNone(result[0].tool_calls)
+        tc = result[0].tool_calls[0]
+        self.assertEqual(tc.id, "tc_1")
+        self.assertEqual(tc.name, "calculator")
+        self.assertEqual(tc.arguments, {"expression": "2+2"})
+
+    def test_tool_result_message_converted(self) -> None:
+        records = [_make_record("tool", "4", tool_call_id="tc_1", tool_name="calculator")]
+        result = session_messages_to_llm_messages(records)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].role, MessageRole.TOOL)
+        self.assertEqual(result[0].content, "4")
+        self.assertEqual(result[0].tool_call_id, "tc_1")
+        self.assertEqual(result[0].name, "calculator")
+
+    def test_system_messages_skipped(self) -> None:
+        records = [
+            _make_record("system", "You are a helper"),
+            _make_record("user", "Hi"),
+        ]
+        result = session_messages_to_llm_messages(records)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].role, MessageRole.USER)
+
+    def test_empty_tool_name_maps_to_none(self) -> None:
+        records = [_make_record("tool", "result", tool_call_id="tc_2", tool_name="")]
+        result = session_messages_to_llm_messages(records)
+        self.assertIsNone(result[0].name)
+
+    def test_chronological_order_preserved(self) -> None:
+        records = [
+            _make_record("user", "first"),
+            _make_record("assistant", "second"),
+            _make_record("user", "third"),
+        ]
+        result = session_messages_to_llm_messages(records)
+        self.assertEqual([m.content for m in result], ["first", "second", "third"])
+
+
+def _make_agent(context_window_messages: int = 0) -> MagicMock:
+    """Build a mock Agent with the given context_window_messages value."""
+    agent = MagicMock()
+    agent.id = 1
+    agent.context_window_messages = context_window_messages
+    agent.system_prompt = ""
+    agent.temperature = 0.7
+    agent.max_tokens = 4096
+    agent.provider = "anthropic"
+    agent.rate_limit_enabled = False
+    return agent
+
+
+def _make_llm_response(content: str = "OK") -> LLMResponse:
+    return LLMResponse(content=content, stop_reason=StopReason.END_TURN)
+
+
+class AgentRunnerTranscriptTests(IsolatedAsyncioTestCase):
+    """Tests for AgentRunner session transcript injection in run()."""
+
+    async def test_no_transcript_when_context_window_messages_is_zero(self) -> None:
+        """When context_window_messages=0, run() must not prepend any history."""
+        agent = _make_agent(context_window_messages=0)
+        runner = AgentRunner(agent, register_builtins=False)
+
+        user_msg = LLMMessage.user("Hello")
+        mock_client = AsyncMock()
+        mock_client.generate = AsyncMock(return_value=_make_llm_response())
+        runner._client = mock_client
+
+        with patch.object(runner, "_load_session_transcript", new_callable=AsyncMock) as mock_load:
+            session = MagicMock()
+            await runner.run([user_msg], session=session, enable_tools=False)
+            mock_load.assert_not_called()
+
+        # Verify the client received exactly the original message
+        called_messages = mock_client.generate.call_args[0][0]
+        self.assertEqual(len(called_messages), 1)
+        self.assertEqual(called_messages[0].content, "Hello")
+
+    async def test_transcript_injected_before_user_message(self) -> None:
+        """Prior session messages are prepended to the incoming message list."""
+        agent = _make_agent(context_window_messages=5)
+        runner = AgentRunner(agent, register_builtins=False)
+
+        prior = [LLMMessage.user("prior message")]
+        user_msg = LLMMessage.user("new message")
+        mock_client = AsyncMock()
+        mock_client.generate = AsyncMock(return_value=_make_llm_response())
+        runner._client = mock_client
+
+        with patch.object(runner, "_load_session_transcript", new_callable=AsyncMock, return_value=prior):
+            session = MagicMock()
+            await runner.run([user_msg], session=session, enable_tools=False)
+
+        called_messages = mock_client.generate.call_args[0][0]
+        self.assertEqual(len(called_messages), 2)
+        self.assertEqual(called_messages[0].content, "prior message")
+        self.assertEqual(called_messages[1].content, "new message")
+
+    async def test_no_session_no_transcript(self) -> None:
+        """When session=None, no transcript loading occurs even if configured."""
+        agent = _make_agent(context_window_messages=5)
+        runner = AgentRunner(agent, register_builtins=False)
+
+        user_msg = LLMMessage.user("Hello")
+        mock_client = AsyncMock()
+        mock_client.generate = AsyncMock(return_value=_make_llm_response())
+        runner._client = mock_client
+
+        with patch.object(runner, "_load_session_transcript", new_callable=AsyncMock) as mock_load:
+            await runner.run([user_msg], session=None, enable_tools=False)
+            mock_load.assert_not_called()
+
+    async def test_empty_transcript_does_not_change_messages(self) -> None:
+        """When the session has no messages, the message list is unchanged."""
+        agent = _make_agent(context_window_messages=5)
+        runner = AgentRunner(agent, register_builtins=False)
+
+        user_msg = LLMMessage.user("Hello")
+        mock_client = AsyncMock()
+        mock_client.generate = AsyncMock(return_value=_make_llm_response())
+        runner._client = mock_client
+
+        with patch.object(runner, "_load_session_transcript", new_callable=AsyncMock, return_value=[]):
+            session = MagicMock()
+            await runner.run([user_msg], session=session, enable_tools=False)
+
+        called_messages = mock_client.generate.call_args[0][0]
+        self.assertEqual(len(called_messages), 1)
+        self.assertEqual(called_messages[0].content, "Hello")
+
+    async def test_load_session_transcript_calls_correct_n(self) -> None:
+        """_load_session_transcript is called with agent.context_window_messages as N."""
+        agent = _make_agent(context_window_messages=7)
+        runner = AgentRunner(agent, register_builtins=False)
+
+        mock_client = AsyncMock()
+        mock_client.generate = AsyncMock(return_value=_make_llm_response())
+        runner._client = mock_client
+
+        with patch.object(runner, "_load_session_transcript", new_callable=AsyncMock, return_value=[]) as mock_load:
+            session = MagicMock()
+            await runner.run([LLMMessage.user("hi")], session=session, enable_tools=False)
+            mock_load.assert_awaited_once_with(session, 7)


### PR DESCRIPTION
Closes #39

## Problem

`AgentRunner` had no mechanism to replay prior conversation history when resuming a session. Each call started with a blank context, making it impossible to maintain coherent multi-turn conversations across invocations.

## Solution

- **`Agent.context_window_messages`** — new `PositiveIntegerField` (default `0`). When `> 0`, enables transcript injection for that agent.
- **`session_messages_to_llm_messages(records)`** — module-level converter that maps `memory.Message` records to `LLMMessage` objects:
  - `role=user` → `LLMMessage.user()`
  - `role=assistant` → `LLMMessage.assistant()`, reconstructing `ToolCall` list from `raw_data["tool_calls"]` if present
  - `role=tool` → `LLMMessage.tool_result()` using `tool_call_id` and `tool_name` from the record
  - `role=system` — skipped (handled via `system_prompt` parameter)
- **`AgentRunner.run(session=...)`** — new optional `session` kwarg. When provided and `agent.context_window_messages > 0`, loads the last N `Message` records for that session (chronological order) and prepends them before the incoming messages.
- Migration `0008_agent_context_window_messages` adds the new field.

## Tests

12 new tests in `mrvn/agents/tests/test_runner.py`:

- Conversion of user, assistant, tool, and system records
- Tool call reconstruction from `raw_data`
- Empty `tool_name` maps to `None`
- Chronological order preserved
- Transcript injected before new message when `context_window_messages > 0`
- No injection when `context_window_messages = 0` (no regression)
- No injection when `session=None`
- Empty transcript does not mutate message list
- `_load_session_transcript` called with correct `n`