### PR TITLE
feat: auto-index messages to EmbeddingChunk on creation

### DIFF
--- a/mrvn/memory/apps.py
+++ b/mrvn/memory/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class MemoryConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "memory"
+
+    def ready(self) -> None:
+        import memory.signals  # noqa: F401, PLC0415

--- a/mrvn/memory/signals.py
+++ b/mrvn/memory/signals.py
@@ -1,0 +1,25 @@
+import logging
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from memory.models import Message, MessageRole
+from memory.search import memory_search_service
+
+logger = logging.getLogger(__name__)
+
+INDEXED_ROLES = {MessageRole.USER, MessageRole.ASSISTANT}
+
+
+@receiver(post_save, sender=Message)
+def handle_message_post_save(_sender: type[Message], instance: Message, created: bool, **_kwargs: object) -> None:
+    """Index new messages for hybrid memory search on creation."""
+    if not created:
+        return
+    if instance.role not in INDEXED_ROLES:
+        return
+    agent_id = instance.session.agent_id
+    if agent_id is None:
+        logger.debug("Skipping indexing for message %s: session has no agent", instance.pk)
+        return
+    memory_search_service.index_message(instance, agent_id)

--- a/mrvn/memory/tests/test_signals.py
+++ b/mrvn/memory/tests/test_signals.py
@@ -1,0 +1,100 @@
+"""Tests for memory signal handlers."""
+
+from unittest.mock import MagicMock, patch
+
+from agents.models import Agent
+from channels.models import Channel, ChannelType, ChatRoom
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from memory.models import Message, MessageRole, Session
+
+User = get_user_model()
+
+
+class MessagePostSaveSignalTests(TestCase):
+    """Tests for handle_message_post_save signal handler."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(username="testuser", password="pass")  # noqa: S106
+        self.agent = Agent.objects.create(name="Test Agent")
+        self.channel = Channel.objects.create(
+            name="test-channel",
+            channel_type=ChannelType.TELEGRAM,
+            owner=self.user,
+        )
+        self.chat_room = ChatRoom.objects.create(
+            channel=self.channel,
+            platform_chat_id="chat-123",
+        )
+        self.session_with_agent = Session.objects.create(
+            chat_room=self.chat_room,
+            agent=self.agent,
+        )
+        self.session_without_agent = Session.objects.create(
+            chat_room=self.chat_room,
+            agent=None,
+        )
+
+    @patch("memory.signals.memory_search_service.index_message")
+    def test_new_user_message_with_agent_triggers_indexing(self, mock_index: MagicMock) -> None:
+        """New USER message on a session with an agent calls index_message."""
+        msg = Message.objects.create(
+            session=self.session_with_agent,
+            role=MessageRole.USER,
+            content="Hello world",
+        )
+        mock_index.assert_called_once_with(msg, self.agent.pk)
+
+    @patch("memory.signals.memory_search_service.index_message")
+    def test_new_assistant_message_with_agent_triggers_indexing(self, mock_index: MagicMock) -> None:
+        """New ASSISTANT message on a session with an agent calls index_message."""
+        msg = Message.objects.create(
+            session=self.session_with_agent,
+            role=MessageRole.ASSISTANT,
+            content="Hi there",
+        )
+        mock_index.assert_called_once_with(msg, self.agent.pk)
+
+    @patch("memory.signals.memory_search_service.index_message")
+    def test_update_does_not_trigger_indexing(self, mock_index: MagicMock) -> None:
+        """Saving an existing message (update) does not call index_message."""
+        msg = Message.objects.create(
+            session=self.session_with_agent,
+            role=MessageRole.USER,
+            content="Original",
+        )
+        mock_index.reset_mock()
+        msg.content = "Updated"
+        msg.save()
+        mock_index.assert_not_called()
+
+    @patch("memory.signals.memory_search_service.index_message")
+    def test_message_without_agent_skips_indexing(self, mock_index: MagicMock) -> None:
+        """New message on a session without an agent does not call index_message."""
+        Message.objects.create(
+            session=self.session_without_agent,
+            role=MessageRole.USER,
+            content="No agent here",
+        )
+        mock_index.assert_not_called()
+
+    @patch("memory.signals.memory_search_service.index_message")
+    def test_tool_message_skips_indexing(self, mock_index: MagicMock) -> None:
+        """New TOOL message is not indexed."""
+        Message.objects.create(
+            session=self.session_with_agent,
+            role=MessageRole.TOOL,
+            content="Tool output",
+        )
+        mock_index.assert_not_called()
+
+    @patch("memory.signals.memory_search_service.index_message")
+    def test_system_message_skips_indexing(self, mock_index: MagicMock) -> None:
+        """New SYSTEM message is not indexed."""
+        Message.objects.create(
+            session=self.session_with_agent,
+            role=MessageRole.SYSTEM,
+            content="System prompt",
+        )
+        mock_index.assert_not_called()


### PR DESCRIPTION
Closes #40

## Problem

Messages saved to `Session` were not indexed for hybrid memory search without manual intervention. This meant the memory search index was always stale unless a batch indexing job was run explicitly.

## Solution

Add a Django `post_save` signal handler (`memory/signals.py`) that automatically calls `memory_search_service.index_message()` whenever a new `Message` is created with a session that has an agent assigned.

**Key decisions:**
- Only `USER` and `ASSISTANT` messages are indexed — `TOOL` and `SYSTEM` messages are excluded to avoid search noise
- Indexing is inline (synchronous) for correctness; async dispatch can be added later if latency becomes a concern
- Sessions with `agent=None` are gracefully skipped with a debug-level log
- Idempotency is handled in `index_message()` itself (content hash check)

## Changes

- `mrvn/memory/signals.py` — new signal handler for `Message` post_save
- `mrvn/memory/apps.py` — register signal in `MemoryConfig.ready()`
- `mrvn/memory/tests/test_signals.py` — unit tests covering all AC scenarios