### PR TITLE
feat: compute adapters module (Lambda, Fargate, Batch)

### DIFF
--- a/marvin/adapters/__init__.py
+++ b/marvin/adapters/__init__.py
@@ -1,0 +1,14 @@
+from marvin.adapters.base import BaseComputeAdapter, DispatchResult
+from marvin.adapters.batch_adapter import BatchAdapter
+from marvin.adapters.factory import AdapterFactory
+from marvin.adapters.fargate_adapter import FargateAdapter
+from marvin.adapters.lambda_adapter import LambdaAdapter
+
+__all__ = [
+    "AdapterFactory",
+    "BaseComputeAdapter",
+    "BatchAdapter",
+    "DispatchResult",
+    "FargateAdapter",
+    "LambdaAdapter",
+]

--- a/marvin/adapters/base.py
+++ b/marvin/adapters/base.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from typing import Literal
+
+from pydantic import BaseModel
+
+from marvin.models import TaskEnvelope
+
+
+class DispatchResult(BaseModel):
+    adapter: str
+    job_id: str | None
+    status: Literal["dispatched", "inline_complete", "failed"]
+    output: str | None = None
+
+
+class BaseComputeAdapter(ABC):
+    @abstractmethod
+    async def dispatch(self, envelope: TaskEnvelope) -> DispatchResult: ...

--- a/marvin/adapters/batch_adapter.py
+++ b/marvin/adapters/batch_adapter.py
@@ -1,0 +1,37 @@
+import os
+
+import boto3
+
+from marvin.adapters.base import BaseComputeAdapter, DispatchResult
+from marvin.definitions import AWS_REGION
+from marvin.models import TaskEnvelope
+
+BATCH_JOB_DEFINITION = os.getenv("BATCH_JOB_DEFINITION", "")
+BATCH_JOB_QUEUE = os.getenv("BATCH_JOB_QUEUE", "")
+
+
+class BatchAdapter(BaseComputeAdapter):
+    def __init__(
+        self,
+        job_definition: str | None = None,
+        job_queue: str | None = None,
+    ) -> None:
+        self.job_definition = job_definition or BATCH_JOB_DEFINITION
+        self.job_queue = job_queue or BATCH_JOB_QUEUE
+
+    async def dispatch(self, envelope: TaskEnvelope) -> DispatchResult:
+        client = boto3.client("batch", region_name=AWS_REGION)
+        envelope_json = envelope.model_dump_json()
+        response = client.submit_job(
+            jobName=f"marvin-task-{envelope.task_id}",
+            jobDefinition=self.job_definition,
+            jobQueue=self.job_queue,
+            containerOverrides={
+                "environment": [
+                    {"name": "TASK_ENVELOPE", "value": envelope_json},
+                ],
+            },
+        )
+        job_id: str | None = response.get("jobId")
+        status = "dispatched" if job_id else "failed"
+        return DispatchResult(adapter="batch", job_id=job_id, status=status)

--- a/marvin/adapters/factory.py
+++ b/marvin/adapters/factory.py
@@ -1,0 +1,18 @@
+from marvin.adapters.base import BaseComputeAdapter
+from marvin.adapters.batch_adapter import BatchAdapter
+from marvin.adapters.fargate_adapter import FargateAdapter
+from marvin.adapters.lambda_adapter import LambdaAdapter
+from marvin.models import TaskEnvelope
+
+LAMBDA_MAX_SECONDS = 600
+FARGATE_MAX_SECONDS = 21600
+
+
+class AdapterFactory:
+    @staticmethod
+    def select(envelope: TaskEnvelope) -> BaseComputeAdapter:
+        if envelope.duration_hint_seconds < LAMBDA_MAX_SECONDS:
+            return LambdaAdapter()
+        if envelope.duration_hint_seconds <= FARGATE_MAX_SECONDS:
+            return FargateAdapter()
+        return BatchAdapter()

--- a/marvin/adapters/fargate_adapter.py
+++ b/marvin/adapters/fargate_adapter.py
@@ -1,0 +1,45 @@
+import os
+
+import boto3
+
+from marvin.adapters.base import BaseComputeAdapter, DispatchResult
+from marvin.definitions import AWS_REGION
+from marvin.models import TaskEnvelope
+
+FARGATE_TASK_DEFINITION_ARN = os.getenv("FARGATE_TASK_DEFINITION_ARN", "")
+FARGATE_CLUSTER = os.getenv("FARGATE_CLUSTER", "")
+
+
+class FargateAdapter(BaseComputeAdapter):
+    def __init__(
+        self,
+        task_definition_arn: str | None = None,
+        cluster: str | None = None,
+    ) -> None:
+        self.task_definition_arn = task_definition_arn or FARGATE_TASK_DEFINITION_ARN
+        self.cluster = cluster or FARGATE_CLUSTER
+
+    async def dispatch(self, envelope: TaskEnvelope) -> DispatchResult:
+        client = boto3.client("ecs", region_name=AWS_REGION)
+        envelope_json = envelope.model_dump_json()
+        response = client.run_task(
+            taskDefinition=self.task_definition_arn,
+            cluster=self.cluster,
+            overrides={
+                "containerOverrides": [
+                    {
+                        "name": "worker",
+                        "environment": [
+                            {"name": "TASK_ENVELOPE", "value": envelope_json},
+                        ],
+                    },
+                ],
+            },
+            launchType="FARGATE",
+        )
+        tasks = response.get("tasks", [])
+        if not tasks:
+            return DispatchResult(adapter="fargate", job_id=None, status="failed")
+        task_arn: str = tasks[0]["taskArn"]
+        job_id = task_arn.split("/")[-1]
+        return DispatchResult(adapter="fargate", job_id=job_id, status="dispatched")

--- a/marvin/adapters/lambda_adapter.py
+++ b/marvin/adapters/lambda_adapter.py
@@ -1,0 +1,13 @@
+from marvin.adapters.base import BaseComputeAdapter, DispatchResult
+from marvin.models import TaskEnvelope
+
+
+class LambdaAdapter(BaseComputeAdapter):
+    """Runs the task inline; used when Lambda IS the compute entry point."""
+
+    async def dispatch(self, envelope: TaskEnvelope) -> DispatchResult:
+        return DispatchResult(
+            adapter="lambda",
+            job_id=None,
+            status="inline_complete",
+        )

--- a/marvin/definitions.py
+++ b/marvin/definitions.py
@@ -1,4 +1,7 @@
+import os
 from enum import Enum
+
+AWS_REGION = os.getenv("AWS_DEFAULT_REGION", "ap-northeast-1")
 
 MAX_S3_BUCKET_LENGTH = 63
 MAX_S3_KEY_LENGTH = 1024

--- a/marvin/models.py
+++ b/marvin/models.py
@@ -100,3 +100,4 @@ class TaskEnvelope(BaseModel):
     conversation_history: list[dict[str, Any]] = Field(default_factory=list)
     enable_tools: bool = True
     max_tool_iterations: int = 10
+    duration_hint_seconds: int = 0

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,148 @@
+"""Tests for marvin.adapters — AdapterFactory, LambdaAdapter, FargateAdapter, BatchAdapter."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from marvin.adapters.batch_adapter import BatchAdapter
+from marvin.adapters.factory import AdapterFactory
+from marvin.adapters.fargate_adapter import FargateAdapter
+from marvin.adapters.lambda_adapter import LambdaAdapter
+from marvin.models import AgentConfig, TaskEnvelope
+
+
+def _make_envelope(duration: int = 0) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id="t-001",
+        customer_id="c-001",
+        session_id="s-001",
+        agent=AgentConfig(name="test-agent"),
+        s3_context_prefix="s3://bucket/prefix",
+        user_message="Hello",
+        duration_hint_seconds=duration,
+    )
+
+
+class TestAdapterFactory:
+    def test_select_lambda_for_short_tasks(self) -> None:
+        adapter = AdapterFactory.select(_make_envelope(100))
+        assert isinstance(adapter, LambdaAdapter)
+
+    def test_select_lambda_at_upper_boundary(self) -> None:
+        adapter = AdapterFactory.select(_make_envelope(599))
+        assert isinstance(adapter, LambdaAdapter)
+
+    def test_select_fargate_at_lower_boundary(self) -> None:
+        adapter = AdapterFactory.select(_make_envelope(600))
+        assert isinstance(adapter, FargateAdapter)
+
+    def test_select_fargate_for_medium_tasks(self) -> None:
+        adapter = AdapterFactory.select(_make_envelope(3600))
+        assert isinstance(adapter, FargateAdapter)
+
+    def test_select_fargate_at_upper_boundary(self) -> None:
+        adapter = AdapterFactory.select(_make_envelope(21600))
+        assert isinstance(adapter, FargateAdapter)
+
+    def test_select_batch_above_fargate_threshold(self) -> None:
+        adapter = AdapterFactory.select(_make_envelope(21601))
+        assert isinstance(adapter, BatchAdapter)
+
+    def test_select_batch_for_long_tasks(self) -> None:
+        adapter = AdapterFactory.select(_make_envelope(86400))
+        assert isinstance(adapter, BatchAdapter)
+
+
+class TestLambdaAdapter:
+    def test_dispatch_returns_inline_complete(self) -> None:
+        adapter = LambdaAdapter()
+        result = asyncio.run(adapter.dispatch(_make_envelope(100)))
+        assert result.adapter == "lambda"
+        assert result.status == "inline_complete"
+        assert result.job_id is None
+
+
+class TestFargateAdapter:
+    def test_dispatch_calls_run_task_and_returns_job_id(self) -> None:
+        mock_ecs = MagicMock()
+        mock_ecs.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-east-1:123456789012:task/my-cluster/abc123def456"}]
+        }
+        with patch("marvin.adapters.fargate_adapter.boto3.client", return_value=mock_ecs):
+            adapter = FargateAdapter(
+                task_definition_arn="arn:aws:ecs:us-east-1:123:task-definition/worker:1",
+                cluster="my-cluster",
+            )
+            result = asyncio.run(adapter.dispatch(_make_envelope(1000)))
+
+        mock_ecs.run_task.assert_called_once()
+        call_kwargs = mock_ecs.run_task.call_args[1]
+        assert call_kwargs["taskDefinition"] == "arn:aws:ecs:us-east-1:123:task-definition/worker:1"
+        assert call_kwargs["cluster"] == "my-cluster"
+        assert call_kwargs["launchType"] == "FARGATE"
+        assert result.adapter == "fargate"
+        assert result.status == "dispatched"
+        assert result.job_id == "abc123def456"
+
+    def test_dispatch_returns_failed_when_no_tasks(self) -> None:
+        mock_ecs = MagicMock()
+        mock_ecs.run_task.return_value = {"tasks": []}
+        with patch("marvin.adapters.fargate_adapter.boto3.client", return_value=mock_ecs):
+            adapter = FargateAdapter(task_definition_arn="arn:task-def", cluster="cluster")
+            result = asyncio.run(adapter.dispatch(_make_envelope(1000)))
+
+        assert result.status == "failed"
+        assert result.job_id is None
+
+    def test_dispatch_passes_task_envelope_as_env_var(self) -> None:
+        mock_ecs = MagicMock()
+        mock_ecs.run_task.return_value = {"tasks": [{"taskArn": "arn:aws:ecs:us-east-1:123:task/cluster/jobid"}]}
+        envelope = _make_envelope(1000)
+        with patch("marvin.adapters.fargate_adapter.boto3.client", return_value=mock_ecs):
+            adapter = FargateAdapter(task_definition_arn="arn:task", cluster="c")
+            asyncio.run(adapter.dispatch(envelope))
+
+        call_kwargs = mock_ecs.run_task.call_args[1]
+        container_overrides = call_kwargs["overrides"]["containerOverrides"]
+        env_vars = {e["name"]: e["value"] for e in container_overrides[0]["environment"]}
+        assert "TASK_ENVELOPE" in env_vars
+        assert envelope.task_id in env_vars["TASK_ENVELOPE"]
+
+
+class TestBatchAdapter:
+    def test_dispatch_calls_submit_job_and_returns_job_id(self) -> None:
+        mock_batch = MagicMock()
+        mock_batch.submit_job.return_value = {"jobId": "batch-job-001"}
+        with patch("marvin.adapters.batch_adapter.boto3.client", return_value=mock_batch):
+            adapter = BatchAdapter(job_definition="marvin-worker-job", job_queue="marvin-queue")
+            result = asyncio.run(adapter.dispatch(_make_envelope(30000)))
+
+        mock_batch.submit_job.assert_called_once()
+        call_kwargs = mock_batch.submit_job.call_args[1]
+        assert call_kwargs["jobDefinition"] == "marvin-worker-job"
+        assert call_kwargs["jobQueue"] == "marvin-queue"
+        assert result.adapter == "batch"
+        assert result.status == "dispatched"
+        assert result.job_id == "batch-job-001"
+
+    def test_dispatch_returns_failed_when_no_job_id(self) -> None:
+        mock_batch = MagicMock()
+        mock_batch.submit_job.return_value = {}
+        with patch("marvin.adapters.batch_adapter.boto3.client", return_value=mock_batch):
+            adapter = BatchAdapter(job_definition="job-def", job_queue="queue")
+            result = asyncio.run(adapter.dispatch(_make_envelope(30000)))
+
+        assert result.status == "failed"
+        assert result.job_id is None
+
+    def test_dispatch_passes_task_envelope_as_env_var(self) -> None:
+        mock_batch = MagicMock()
+        mock_batch.submit_job.return_value = {"jobId": "batch-job-002"}
+        envelope = _make_envelope(30000)
+        with patch("marvin.adapters.batch_adapter.boto3.client", return_value=mock_batch):
+            adapter = BatchAdapter(job_definition="job-def", job_queue="queue")
+            asyncio.run(adapter.dispatch(envelope))
+
+        call_kwargs = mock_batch.submit_job.call_args[1]
+        env_vars = {e["name"]: e["value"] for e in call_kwargs["containerOverrides"]["environment"]}
+        assert "TASK_ENVELOPE" in env_vars
+        assert envelope.task_id in env_vars["TASK_ENVELOPE"]


### PR DESCRIPTION
Closes #10

## Summary

- Adds `marvin/adapters/` package with `BaseComputeAdapter` ABC and `DispatchResult` Pydantic model
- `LambdaAdapter`: returns `inline_complete` (task runs in-process; used when Lambda is the entry point)
- `FargateAdapter`: calls `ecs.run_task()` with the serialised `TaskEnvelope` as an env var override
- `BatchAdapter`: calls `batch.submit_job()` with the serialised `TaskEnvelope` as an env var override
- `AdapterFactory.select(envelope)`: routes by `duration_hint_seconds` — `<600s` → Lambda, `600–21600s` → Fargate, `>21600s` → Batch
- Adds `duration_hint_seconds: int = 0` field to `TaskEnvelope`
- Consolidates `AWS_REGION` constant into `marvin/definitions.py` (was duplicated across adapters)

## Test plan

- [x] `uv run pytest tests/test_adapters.py -v` — 14 tests covering factory boundary conditions, all three adapter dispatch paths, boto3 mock verification, and env-var pass-through
- [x] `uv run pytest` — full suite (71 tests) passes with no regressions
- [x] `uv run ruff check marvin/adapters/` — no lint errors