### PR TITLE
feat: session transcript replay via context_window_messages

### DIFF
--- a/marvin/models.py
+++ b/marvin/models.py
@@ -39,6 +39,7 @@ class AgentConfig(BaseModel):
     memory_search_config: dict[str, Any] = Field(default_factory=dict)
     config: dict[str, Any] = Field(default_factory=dict)
     api_key: str | None = None  # Provider API key
+    context_window_messages: int = 0  # 0 = disabled; >0 injects last N messages on resume
 
     def get_allowed_tools(self, available_tools: list[str]) -> list[str]:
         """Calculate which tools this agent can use."""

--- a/marvin/runner.py
+++ b/marvin/runner.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 from marvin.llm import LLMMessage, LLMResponse
+from marvin.llm.base import ToolCall
 from marvin.llm.factory import create_client_from_agent_config
 from marvin.models import AgentConfig
 from marvin.rate_limiter import rate_limiter_registry
@@ -11,6 +12,50 @@ from marvin.tools import ToolRegistry
 from marvin.tools.builtin import register_builtin_tools
 
 logger = logging.getLogger(__name__)
+
+
+def history_to_llm_messages(records: list[dict[str, Any]]) -> list[LLMMessage]:
+    """Convert conversation history dicts to LLMMessage objects.
+
+    Handles user, assistant (with optional tool calls), tool result, and system
+    messages. System messages are included; unknown roles fall back to user.
+
+    Args:
+        records: List of message dicts with at minimum a "role" and "content" key.
+            Tool result records must include "tool_call_id".
+            Assistant records with tool calls must include "tool_calls" list.
+
+    Returns:
+        List of LLMMessage objects in the same order as the input.
+    """
+    messages: list[LLMMessage] = []
+    for record in records:
+        role = record.get("role", "user")
+        content = record.get("content", "")
+
+        if role == "system":
+            messages.append(LLMMessage.system(content))
+        elif role == "assistant":
+            tool_calls_data = record.get("tool_calls")
+            tool_calls: list[ToolCall] | None = None
+            if tool_calls_data:
+                tool_calls = [
+                    ToolCall(
+                        id=tc["id"],
+                        name=tc["name"],
+                        arguments=tc.get("arguments", {}),
+                    )
+                    for tc in tool_calls_data
+                ]
+            messages.append(LLMMessage.assistant(content, tool_calls))
+        elif role == "tool":
+            tool_call_id = record.get("tool_call_id", "")
+            name = record.get("name")
+            messages.append(LLMMessage.tool_result(tool_call_id, content, name))
+        else:
+            messages.append(LLMMessage.user(content))
+
+    return messages
 
 
 class AgentRunner:
@@ -179,8 +224,11 @@ class AgentRunner:
         Returns:
             Tuple of (assistant response text, updated history).
         """
-        messages = list(conversation_history or [])
-        messages.append(LLMMessage.user(user_message))
+        history = list(conversation_history or [])
+        n = self.agent.context_window_messages if self.agent else 0
+        if n > 0:
+            history = history[-n:]
+        messages = history + [LLMMessage.user(user_message)]
 
         response, history = await self.run(
             messages,

--- a/marvin/worker.py
+++ b/marvin/worker.py
@@ -15,7 +15,7 @@ import boto3
 from marvin.context import ContextBundleService
 from marvin.llm import LLMMessage
 from marvin.models import TaskEnvelope
-from marvin.runner import AgentRunner
+from marvin.runner import AgentRunner, history_to_llm_messages
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +48,7 @@ async def process_envelope(envelope: TaskEnvelope) -> dict[str, Any]:
     context = context_service.pull(envelope.s3_context_prefix)
     logger.info("Pulled context for customer=%s", context.customer_id)
 
-    messages: list[LLMMessage] = []
-    for msg in envelope.conversation_history:
-        role = msg.get("role", "user")
-        content = msg.get("content", "")
-        if role == "system":
-            messages.append(LLMMessage.system(content))
-        elif role == "assistant":
-            messages.append(LLMMessage.assistant(content))
-        else:
-            messages.append(LLMMessage.user(content))
+    messages: list[LLMMessage] = history_to_llm_messages(envelope.conversation_history)
 
     # Use agent's system prompt; fall back to S3 CLAUDE.md when unset
     system_prompt = envelope.agent.system_prompt or context.claude_md or None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,10 +7,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from marvin.llm.base import LLMMessage, LLMResponse, StopReason
-from marvin.models import AgentConfig, LLMProvider, ToolProfile
-from marvin.runner import AgentRunner
+from marvin.models import AgentConfig, LLMProvider
+from marvin.runner import AgentRunner, history_to_llm_messages
 from marvin.tools import ToolRegistry
-from marvin.tools.base import ToolResult
 
 
 def _make_agent(**kwargs: Any) -> AgentConfig:
@@ -141,9 +140,7 @@ class TestAgentRunnerChat:
         runner = AgentRunner(agent=agent, register_builtins=False)
         mock_client = self._patch_client(runner)
 
-        asyncio.run(
-            runner.chat("Hi", system_prompt="Override prompt.", enable_tools=False)
-        )
+        asyncio.run(runner.chat("Hi", system_prompt="Override prompt.", enable_tools=False))
 
         call_kwargs = mock_client.generate.call_args[1]
         assert call_kwargs.get("system_prompt") == "Override prompt."
@@ -155,3 +152,145 @@ class TestAgentRunnerChat:
 
         # Should complete without blocking
         asyncio.run(runner.chat("Hi", enable_tools=False))
+
+
+class TestHistoryToLlmMessages:
+    def test_user_message(self) -> None:
+        records = [{"role": "user", "content": "Hello"}]
+        result = history_to_llm_messages(records)
+        assert len(result) == 1
+        assert result[0].role.value == "user"
+        assert result[0].content == "Hello"
+
+    def test_assistant_message(self) -> None:
+        records = [{"role": "assistant", "content": "Hi there"}]
+        result = history_to_llm_messages(records)
+        assert len(result) == 1
+        assert result[0].role.value == "assistant"
+        assert result[0].content == "Hi there"
+        assert result[0].tool_calls is None
+
+    def test_assistant_message_with_tool_calls(self) -> None:
+        records = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "tc1", "name": "calculator", "arguments": {"expression": "1+1"}}],
+            }
+        ]
+        result = history_to_llm_messages(records)
+        assert len(result) == 1
+        assert result[0].tool_calls is not None
+        assert len(result[0].tool_calls) == 1
+        tc = result[0].tool_calls[0]
+        assert tc.id == "tc1"
+        assert tc.name == "calculator"
+        assert tc.arguments == {"expression": "1+1"}
+
+    def test_tool_result_message(self) -> None:
+        records = [{"role": "tool", "content": "2", "tool_call_id": "tc1", "name": "calculator"}]
+        result = history_to_llm_messages(records)
+        assert len(result) == 1
+        assert result[0].role.value == "tool"
+        assert result[0].content == "2"
+        assert result[0].tool_call_id == "tc1"
+        assert result[0].name == "calculator"
+
+    def test_system_message(self) -> None:
+        records = [{"role": "system", "content": "You are helpful."}]
+        result = history_to_llm_messages(records)
+        assert len(result) == 1
+        assert result[0].role.value == "system"
+
+    def test_unknown_role_falls_back_to_user(self) -> None:
+        records = [{"role": "unknown", "content": "test"}]
+        result = history_to_llm_messages(records)
+        assert result[0].role.value == "user"
+
+    def test_empty_records(self) -> None:
+        assert history_to_llm_messages([]) == []
+
+    def test_mixed_roles_preserves_order(self) -> None:
+        records = [
+            {"role": "user", "content": "Q"},
+            {"role": "assistant", "content": "A"},
+            {"role": "tool", "content": "result", "tool_call_id": "x"},
+        ]
+        result = history_to_llm_messages(records)
+        assert len(result) == 3
+        assert result[0].role.value == "user"
+        assert result[1].role.value == "assistant"
+        assert result[2].role.value == "tool"
+
+
+class TestContextWindowMessages:
+    def _patch_client(self, runner: AgentRunner, response_content: str = "Reply") -> MagicMock:
+        mock_client = MagicMock()
+        mock_response = _make_response(response_content)
+        mock_client.generate = AsyncMock(return_value=mock_response)
+        mock_client.generate_with_tools = AsyncMock(
+            return_value=(mock_response, [LLMMessage.user("Hi"), LLMMessage.assistant(response_content)])
+        )
+        runner._client = mock_client
+        return mock_client
+
+    def _get_input_messages(self, mock_client: MagicMock) -> list[LLMMessage]:
+        """Extract the messages list passed to generate, excluding any post-call appends.
+
+        When enable_tools=False, run() sets history=messages (same reference), so
+        chat()'s append mutates the list visible in call_args. We slice off the last
+        element (the assistant message appended after generate returns) to get the
+        exact list that was passed in.
+        """
+        raw: list[LLMMessage] = mock_client.generate.call_args[0][0]
+        return raw[:-1]  # exclude the assistant message appended by chat()
+
+    def test_zero_context_window_passes_full_history(self) -> None:
+        agent = _make_agent(context_window_messages=0)
+        runner = AgentRunner(agent=agent, register_builtins=False)
+        mock_client = self._patch_client(runner)
+
+        history = [LLMMessage.user(f"msg{i}") for i in range(5)]
+        asyncio.run(runner.chat("new", conversation_history=history, enable_tools=False))
+
+        messages_passed = self._get_input_messages(mock_client)
+        # All 5 history messages + the new user message = 6
+        assert len(messages_passed) == 6
+
+    def test_context_window_limits_injected_messages(self) -> None:
+        agent = _make_agent(context_window_messages=2)
+        runner = AgentRunner(agent=agent, register_builtins=False)
+        mock_client = self._patch_client(runner)
+
+        history = [LLMMessage.user(f"msg{i}") for i in range(5)]
+        asyncio.run(runner.chat("new", conversation_history=history, enable_tools=False))
+
+        messages_passed = self._get_input_messages(mock_client)
+        # Last 2 history messages + the new user message = 3
+        assert len(messages_passed) == 3
+        assert messages_passed[0].content == "msg3"
+        assert messages_passed[1].content == "msg4"
+        assert messages_passed[2].content == "new"
+
+    def test_context_window_larger_than_history_uses_full_history(self) -> None:
+        agent = _make_agent(context_window_messages=10)
+        runner = AgentRunner(agent=agent, register_builtins=False)
+        mock_client = self._patch_client(runner)
+
+        history = [LLMMessage.user(f"msg{i}") for i in range(3)]
+        asyncio.run(runner.chat("new", conversation_history=history, enable_tools=False))
+
+        messages_passed = self._get_input_messages(mock_client)
+        # All 3 + new = 4
+        assert len(messages_passed) == 4
+
+    def test_context_window_with_no_history(self) -> None:
+        agent = _make_agent(context_window_messages=5)
+        runner = AgentRunner(agent=agent, register_builtins=False)
+        mock_client = self._patch_client(runner)
+
+        asyncio.run(runner.chat("first message", enable_tools=False))
+
+        messages_passed = self._get_input_messages(mock_client)
+        assert len(messages_passed) == 1
+        assert messages_passed[0].content == "first message"


### PR DESCRIPTION
## Summary

- Adds `context_window_messages: int = 0` field to `AgentConfig`; when `> 0`, `AgentRunner.chat()` injects only the last N messages from conversation history into context before the new user message
- Adds `history_to_llm_messages()` module-level utility in `runner.py` to convert dict-format history records to `LLMMessage` objects, correctly handling user, assistant (with tool calls), tool-result, and system roles
- Updates `worker.py` to use `history_to_llm_messages()`, replacing the previous partial implementation that silently dropped tool messages

Re-implements wyc6k-task-runner#39 for the pure Python `marvin/` package (previous implementation PR #44 targeted the now-removed Django `mrvn/` app).

## Test plan

- [x] `TestHistoryToLlmMessages` — 8 tests covering each role type, tool call reconstruction from dict, and ordering
- [x] `TestContextWindowMessages` — 4 tests: window=0 passes full history (no regression), window limits to last N, window larger than history, empty history
- [x] All 69 existing tests continue to pass

Closes #39