### PR TITLE
chore: add Claude Code artifact patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,7 @@ cache/
 output/
 notebooks/*.jpg
 CLAUDE.md
+
+# Claude Code
+.claude/worktrees/
+CHECKPOINT.md


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` and `CHECKPOINT.md` (where missing) to `.gitignore`
- Prevents Claude Code agent worktree artifacts from being committed to PR branches

Closes weyucou/task-management#52

## Test plan

- [ ] Confirm patterns appear in `.gitignore`