### PR TITLE
chore: gitignore Claude Code artifacts (.claude/, CHECKPOINT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,7 @@ cache/
 output/
 notebooks/*.jpg
 CLAUDE.md
+
+# Claude Code artifacts
+.claude/
+CHECKPOINT*.md


### PR DESCRIPTION
Adds `.claude/` and `CHECKPOINT*.md` to `.gitignore` to prevent Claude Code session artifacts from being committed.