### PR TITLE
chore: ignore Claude Code runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,5 @@ cache/
 output/
 notebooks/*.jpg
 CLAUDE.md
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Adds `.claude/settings.local.json` and `.claude/worktrees/` to `.gitignore` so untracked local Claude state stops appearing in `git status`.

## Test plan

- [x] No real source changes; only `.gitignore` updated
- [ ] CI passes